### PR TITLE
Remove sanitisation 2

### DIFF
--- a/src/api/manager/resolvers.js
+++ b/src/api/manager/resolvers.js
@@ -53,13 +53,19 @@ async function addTransaction({ txHash, txState }) {
     updatedAt: new Date().getTime(),
     __typename: 'Transaction'
   }
-  
+
   const previous = client.readQuery({ query: GET_TRANSACTION_HISTORY })
-  const index = previous.transactionHistory.findIndex(trx => trx.txHash === txHash)
+  const index = previous.transactionHistory.findIndex(
+    trx => trx.txHash === txHash
+  )
   const newTransactionHistory = [...previous.transactionHistory]
-  if(index >= 0 ){
-    newTransactionHistory[index] = { ...newTransactionHistory[index], txState, updatedAt: newTransaction.updatedAt}
-  }else{
+  if (index >= 0) {
+    newTransactionHistory[index] = {
+      ...newTransactionHistory[index],
+      txState,
+      updatedAt: newTransaction.updatedAt
+    }
+  } else {
     newTransactionHistory.push(newTransaction)
   }
 
@@ -109,13 +115,6 @@ const resolvers = {
         }
         let data
         if (nameArray.length < 3 && nameArray[1] === 'eth') {
-          if (nameArray[0].length < 7) {
-            cache.writeData({
-              data: defaults
-            })
-            return null
-          }
-
           const entry = await getEntry(nameArray[0])
           const {
             state,
@@ -289,7 +288,7 @@ const resolvers = {
     },
     setContent: async (_, { name, recordValue }, { cache }) => {
       try {
-        const  tx = await setContent(name, recordValue)
+        const tx = await setContent(name, recordValue)
         console.log(tx)
         return sendHelper(tx)
       } catch (e) {

--- a/src/components/Error/Errors.js
+++ b/src/components/Error/Errors.js
@@ -12,6 +12,6 @@ export const NetworkError = ({ message }) => (
   <ErrorContainer>
     {message}
     <br />
-    Please change your dapp browser to Mainnet or Ropsten
+    Please change your dapp browser to Mainnet, Ropsten, Rinkeby or Goerli
   </ErrorContainer>
 )

--- a/src/routes/SingleName.js
+++ b/src/routes/SingleName.js
@@ -1,5 +1,5 @@
-import React, { Component } from 'react'
-import { parseSearchTerm } from '../utils/utils'
+import React, { Component, useState, useEffect } from 'react'
+import { validateName } from '../utils/utils'
 import { GET_SINGLE_NAME } from '../graphql/queries'
 import { Query } from 'react-apollo'
 import Loader from '../components/Loader'
@@ -7,65 +7,47 @@ import SearchErrors from '../components/SearchErrors/SearchErrors'
 
 import Name from '../components/SingleName/Name'
 
-class SingleName extends Component {
-  state = {
-    valid: false
-  }
-  checkValidity = () => {
-    const searchTerm = this.props.match.params.name
-    const validity = parseSearchTerm(searchTerm)
-    const valid = validity === 'supported' || validity === 'tld'
+function SingleName({
+  match: {
+    params: { name: searchTerm }
+  },
+  location: { pathname }
+}) {
+  const [valid, setValid] = useState(false)
 
-    this.setState({ valid, validityType: validity })
-    if (valid) {
-      document.title = searchTerm
-    } else {
-      document.title = 'Error finding name'
-    }
-  }
-  componentDidMount() {
-    this.checkValidity()
-  }
-  componentDidUpdate(prevProps) {
-    if (prevProps.match.params.name !== this.props.match.params.name) {
-      this.checkValidity()
-    }
-  }
-  render() {
-    const {
-      match: {
-        params: { name: searchTerm }
-      },
-      location: { pathname }
-    } = this.props
-    if (this.state.valid) {
-      return (
-        <Query query={GET_SINGLE_NAME} variables={{ name: searchTerm }}>
-          {({ loading, error, data, refetch }) => {
-            if (loading) return <Loader large center />
-            if (error)
-              return <div>{(console.log(error), JSON.stringify(error))}</div>
-            return (
-              <Name
-                details={data.singleName}
-                name={searchTerm}
-                pathname={pathname}
-                refetch={refetch}
-              />
-            )
-          }}
-        </Query>
-      )
+  useEffect(() => {
+    let valid = false
+    try {
+      valid = validateName(searchTerm) && true
+      setValid(valid)
+    } catch (e) {
+      setValid(false)
     }
 
-    if (this.state.validityType === 'short') {
-      return <SearchErrors errors={['tooShort']} searchTerm={searchTerm} />
-    } else {
-      return (
-        <SearchErrors errors={['domainMalformed']} searchTerm={searchTerm} />
-      )
-    }
+    document.title = valid ? searchTerm : 'Error finding name'
+  })
+
+  if (valid) {
+    return (
+      <Query query={GET_SINGLE_NAME} variables={{ name: searchTerm }}>
+        {({ loading, error, data, refetch }) => {
+          if (loading) return <Loader large center />
+          if (error)
+            return <div>{(console.log(error), JSON.stringify(error))}</div>
+          return (
+            <Name
+              details={data.singleName}
+              name={searchTerm}
+              pathname={pathname}
+              refetch={refetch}
+            />
+          )
+        }}
+      </Query>
+    )
   }
+
+  return <SearchErrors errors={['domainMalformed']} searchTerm={searchTerm} />
 }
 
 export default SingleName

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -49,6 +49,8 @@ export const mergeLabels = (labels1, labels2) =>
   labels1.map((label, index) => (label ? label : labels2[index]))
 
 export function validateName(name) {
+  const hasEmptyLabels = name.split('.').filter(e => e.length < 1).length > 0
+  if (hasEmptyLabels) throw new Error('Domain cannot have empty labels')
   try {
     return uts46.toUnicode(name, {
       useStd3ASCII: true,


### PR DESCRIPTION
I've added sanitisation back in, but only to validate a name. The reason it was blowing up before on a...eth was because `web3.utils.sha3` returns null when giving it an empty string. This is a bug that i'll file with web3, but the really it's not an issue for us if we just validate the name so we can't have empty labels. So i've edited the validation function to check for that as well as running the normal domain name validation.

