### PR TITLE
Display expired time

### DIFF
--- a/src/api/manager/resolvers.js
+++ b/src/api/manager/resolvers.js
@@ -11,7 +11,8 @@ import {
   setContent,
   setContenthash,
   registerTestdomain,
-  createSubdomain
+  createSubdomain,
+  expiryTimes
 } from '../registry'
 import { getEntry } from '../registrar'
 import { query } from '../subDomainRegistrar'
@@ -105,7 +106,8 @@ const resolvers = {
           rent: null,
           referralFeePPM: null,
           available: null,
-          contentType: null
+          contentType: null,
+          expiryTime: null
         }
         let data
         if (nameArray.length < 3 && nameArray[1] === 'eth') {
@@ -136,6 +138,11 @@ const resolvers = {
             highestBid,
             owner,
             __typename: 'Node'
+          }
+        } else if (nameArray.length < 3 && nameArray[1] === 'test') {
+          const expiryTime = await expiryTimes(nameArray[0])
+          if(expiryTime){
+            node.expiryTime = expiryTime
           }
         } else if (nameArray.length > 2) {
           if (networkId === 1) {

--- a/src/api/registry.js
+++ b/src/api/registry.js
@@ -38,6 +38,16 @@ export async function registerTestdomain(label) {
   return () => registrar.register(namehash, account).send({ from: account })
 }
 
+export async function expiryTimes(label, owner) {
+  const { registrar } = await getTestRegistrarContract()
+  const web3 = await getWeb3()
+  const namehash = await web3.utils.sha3(label)
+  const result = await registrar.expiryTimes(namehash).call()
+  if(result > 0){
+    return new Date(result * 1000)
+  }
+}
+
 export async function getAddr(name) {
   const resolverAddr = await getResolver(name)
   if (parseInt(resolverAddr, 16) === 0) {

--- a/src/api/schema.js
+++ b/src/api/schema.js
@@ -61,6 +61,7 @@ const typeDefs = `
     contentType: String
     addr: String
     nodes: [Node]
+    expiryTime: Int
   }
 
   extend type Query {

--- a/src/components/SingleName/NameDetails.js
+++ b/src/components/SingleName/NameDetails.js
@@ -34,6 +34,15 @@ const Records = styled('div')`
   display: ${p => (!p.isOwner && !p.hasRecord ? 'none' : 'block')};
 `
 
+const ExpirationDetailsValue = styled(DetailsValue)`
+  color: ${ p => (p.isExpired ? 'red' : null) }
+`
+
+function canClaim(domain){
+  if(!domain.name.match(/\.test$/)) return false
+  return parseInt(domain.owner) == 0 || domain.expiryTime < new Date()
+}
+
 class NameDetails extends Component {
   isEmpty(record) {
     if (parseInt(record, 16) === 0) {
@@ -124,6 +133,16 @@ class NameDetails extends Component {
               ) : (
                 ''
               )}
+              {domain.expiryTime ? (
+                <DetailsItem uneditable>
+                  <DetailsKey>Expiration Date</DetailsKey>
+                  <ExpirationDetailsValue isExpired = {domain.expiryTime < new Date()}>
+                    {formatDate(domain.expiryTime)}
+                  </ExpirationDetailsValue>
+                </DetailsItem>
+              ) : (
+                ''
+              )}
               <HR />
               <DetailsItemEditable
                 keyName="Resolver"
@@ -173,7 +192,7 @@ class NameDetails extends Component {
                   </>
                 )}
               </Records>
-              {parseInt(domain.owner) == 0 && domain.name.match(/\.test$/) ? (
+              {canClaim(domain)  ? (
                 <NameClaimTestDomain domain={domain} refetch={refetch} />
               ): null}
             </Details>

--- a/src/graphql/queries.js
+++ b/src/graphql/queries.js
@@ -55,6 +55,7 @@ export const GET_SINGLE_NAME = gql`
       rent
       referralFeePPM
       available
+      expiryTime
     }
   }
 


### PR DESCRIPTION
## Changes

- Adds `Expiration date` (same formatting as "Registration date"). Colour as red if already expired.
- Make it claimable if owner is empty or it is expired

<img width="1124" alt="screenshot 2019-02-25 at 13 31 17" src="https://user-images.githubusercontent.com/2630/53341035-5d53c680-3902-11e9-9e24-34f862524028.png">

## Examples (On Ropsten)

- http://imaginary-summer.surge.sh/name/makoto.test (Expired)
- http://imaginary-summer.surge.sh/name/makoto2.test (Expiring)
- http://imaginary-summer.surge.sh/name/makoto3.test (Not owned)
- http://imaginary-summer.surge.sh/name/resolver.eth (not `.test`)
