### PR TITLE
Make claim button skinny

### DIFF
--- a/src/components/SingleName/NameClaimTestDomain.js
+++ b/src/components/SingleName/NameClaimTestDomain.js
@@ -12,7 +12,7 @@ const NameClaimTestDomainContainer = styled('div')`
   display: flex;
   flex-direction: column;
   justify-content: space-between;
-  align-items: flex-start;
+  align-items: center;
   ${mq.medium`
     flex-direction: row-reverse;
   `};

--- a/src/components/SingleName/NameClaimTestDomain.js
+++ b/src/components/SingleName/NameClaimTestDomain.js
@@ -12,6 +12,7 @@ const NameClaimTestDomainContainer = styled('div')`
   display: flex;
   flex-direction: column;
   justify-content: space-between;
+  align-items: flex-start;
   ${mq.medium`
     flex-direction: row-reverse;
   `};


### PR DESCRIPTION
This change changes the style of claim button

<img width="455" alt="screenshot 2019-02-27 at 08 59 12" src="https://user-images.githubusercontent.com/2630/53480225-acb90480-3a72-11e9-8533-eae12b87a8d2.png">


Change deployed at http://imaginary-summer.surge.sh