### PR TITLE
Add transfer registrar

### DIFF
--- a/src/api/registrar.js
+++ b/src/api/registrar.js
@@ -14,8 +14,8 @@ let permanentRegistrarControllerRead
 export const getLegacyAuctionRegistrar = async () => {
   if (ethRegistrar) {
     return {
-      ethRegistrar,
-      ethRegistrarRead
+      ethRegistrar: ethRegistrar.methods,
+      ethRegistrarRead: ethRegistrarRead.methods
     }
   }
   try {
@@ -298,4 +298,16 @@ export const startAuctionsAndBid = async (
     from: account,
     value: web3.utils.toWei(decoyBidAmount, 'ether')
   })
+}
+
+
+export const transferRegistrars = async (label) => {
+  const { ethRegistrar } = await getLegacyAuctionRegistrar()
+  const account = await getAccount()
+  const web3 = await getWeb3()
+  const hash = web3.utils.sha3(label)
+  return () =>
+    ethRegistrar.transferRegistrars(hash).send({
+      from: account, gas:2000000
+    })  
 }

--- a/src/api/registrar.js
+++ b/src/api/registrar.js
@@ -304,6 +304,7 @@ export const startAuctionsAndBid = async (
 export const transferRegistrars = async (label) => {
   const { ethRegistrar } = await getLegacyAuctionRegistrar()
   const account = await getAccount()
+  const web3 = await getWeb3()
   const hash = web3.utils.sha3(label)
   return () =>
     ethRegistrar.transferRegistrars(hash).send({

--- a/src/api/registrar.js
+++ b/src/api/registrar.js
@@ -304,10 +304,9 @@ export const startAuctionsAndBid = async (
 export const transferRegistrars = async (label) => {
   const { ethRegistrar } = await getLegacyAuctionRegistrar()
   const account = await getAccount()
-  const web3 = await getWeb3()
   const hash = web3.utils.sha3(label)
   return () =>
     ethRegistrar.transferRegistrars(hash).send({
-      from: account, gas:2000000
+      from: account
     })  
 }

--- a/src/api/registrar/resolvers.js
+++ b/src/api/registrar/resolvers.js
@@ -4,7 +4,8 @@ import {
   getRentPrice,
   commit,
   getMinimumCommitmentAge,
-  register
+  register,
+  transferRegistrars
 } from '../registrar'
 import { getOwner } from '../registry'
 import modeNames from '../modes'
@@ -87,6 +88,10 @@ const resolvers = {
     },
     async bid(_, { name, bidAmount, decoyBidAmount, secret }) {
       // const sealedBid = await createSealedBid(name, bidAmount, secret)
+    },
+    async transferRegistrars(_, { label }) {
+      const tx = await transferRegistrars(label)
+      return sendHelper(tx)
     }
   }
 }

--- a/src/components/SingleName/NameDetails.js
+++ b/src/components/SingleName/NameDetails.js
@@ -9,7 +9,7 @@ import RecordsItem from './RecordsItem'
 import DetailsItemEditable from './DetailsItemEditable'
 import AddRecord from './AddRecord'
 import SetupName from '../SetupName/SetupName'
-import Button from '../Forms/Button'
+import TransferRegistrars from './TransferRegistrars'
 
 import {
   SET_OWNER,
@@ -148,19 +148,7 @@ class NameDetails extends Component {
               ) : (
                 ''
               )}
-              {!domain.isNewRegistrar ? (
-                <DetailsItem>
-                  You have not migrated into permanent registrar yet.
-                  <br/>
-                  Please migrate by xxx.
-                  <br/>
-                  Failing to migrate by the deadline will lead to you losing the domain name.
-                  <Button style={{ width: '160px',   marginLeft: 'auto' }}>Migrate Now</Button>
-                </DetailsItem>
-              ) : (
-                ''
-              )}
-
+              {isOwner && !domain.isNewRegistrar ? (<TransferRegistrars label={domain.label} refetch={refetch} ></TransferRegistrars>) : ''  }
               <HR />
               <DetailsItemEditable
                 keyName="Resolver"

--- a/src/components/SingleName/TransferRegistrars.js
+++ b/src/components/SingleName/TransferRegistrars.js
@@ -1,15 +1,17 @@
-import React, { Fragment, Component } from 'react'
-import styled from '@emotion/styled'
-import { DetailsItem } from './DetailsItem'
-import Button from '../Forms/Button'
+import React from 'react'
 import { Mutation } from 'react-apollo'
-import PendingTx from '../PendingTx'
+import styled from '@emotion/styled'
+
 import { useEditable } from '../hooks'
 import mq from 'mediaQuery'
-
 import {
   TRANSFER_REGISTRARS
 } from '../../graphql/mutations'
+
+import { DetailsItem } from './DetailsItem'
+import Button from '../Forms/Button'
+import PendingTx from '../PendingTx'
+
 
 const TransferButton = styled(Button)`
   width:130px;

--- a/src/components/SingleName/TransferRegistrars.js
+++ b/src/components/SingleName/TransferRegistrars.js
@@ -1,0 +1,77 @@
+import React, { Fragment, Component } from 'react'
+import styled from '@emotion/styled'
+import { DetailsItem } from './DetailsItem'
+import Button from '../Forms/Button'
+import { Mutation } from 'react-apollo'
+import PendingTx from '../PendingTx'
+import { useEditable } from '../hooks'
+import mq from 'mediaQuery'
+
+import {
+  TRANSFER_REGISTRARS
+} from '../../graphql/mutations'
+
+const TransferButton = styled(Button)`
+  width:130px;
+`
+
+const TransferDetail = styled(DetailsItem)`
+  padding:15px;
+  background-color:#f0f6fa;
+  
+  ${mq.small`
+    padding-right: 150px;
+    padding-left: 15px;
+  `}
+`
+
+const Action = styled('div')`
+  margin-bottom: 1em;
+  ${mq.small`
+    margin-top: 0;
+    position: absolute;
+    top: 68%;
+    right:50px;
+    transform: translate(0, -65%);
+  `}
+`
+
+function TransferRegistrars({label, refetch}){
+  const { state, actions } = useEditable()
+  const { txHash, pending, confirmed } = state
+  const { startPending, setConfirmed } = actions
+  return(
+    <>
+      <TransferDetail>
+        You have not migrated into permanent registrar yet.
+        <br/>
+        Please migrate by xxx.
+        <br/>
+        Failing to migrate by the deadline will lead you losing the domain name.
+      </TransferDetail>
+      <Action>
+        {pending && !confirmed && txHash ? (
+          <PendingTx
+            txHash={txHash}
+            onConfirmed={() => {
+              setConfirmed()
+              refetch()
+            }}
+          />
+        ) : (
+          <Mutation
+          mutation={TRANSFER_REGISTRARS}
+          variables={{ label }}
+          onCompleted={data => {
+            startPending(Object.values(data)[0])
+          }}
+          >
+            {mutate => <TransferButton onClick={mutate} >Migrate</TransferButton>}
+          </Mutation>
+        )}
+      </Action>
+    </>
+  )
+}
+
+export default TransferRegistrars

--- a/src/graphql/mutations.js
+++ b/src/graphql/mutations.js
@@ -114,3 +114,9 @@ export const REGISTER = gql`
     register(label: $label, duration: $duration, secret: $secret) @client
   }
 `
+
+export const TRANSFER_REGISTRARS = gql`
+  mutation transferRegistrars($label: String) {
+    transferRegistrars(label: $label) @client
+  }
+`

--- a/src/testing-utils/deployENS.js
+++ b/src/testing-utils/deployENS.js
@@ -198,7 +198,17 @@ module.exports = async function deployENS({ web3, accounts }) {
       from: accounts[0]
     })
 
-  await auctionLegacyName(web3, accounts[0], legacyAuctionRegistrarContract, 'auctionedname')
+  // Can migrate now
+  await auctionLegacyName(web3, accounts[0], legacyAuctionRegistrarContract, 'auctioned1')
+  await auctionLegacyName(web3, accounts[0], legacyAuctionRegistrarContract, 'auctioned2')
+  await auctionLegacyName(web3, accounts[0], legacyAuctionRegistrarContract, 'auctioned3')
+  await auctionLegacyName(web3, accounts[0], legacyAuctionRegistrarContract, 'auctioned4')
+  await auctionLegacyName(web3, accounts[0], legacyAuctionRegistrarContract, 'auctioned5')
+  const lockoutlength = 60 * 60 * 24 * 190
+  await advanceTime(web3, lockoutlength)
+  await mine(web3)
+  // Need to wait for the lock period to end
+  await auctionLegacyName(web3, accounts[0], legacyAuctionRegistrarContract, 'auctionedtoorecent')
 
   let rootOwner = await ensContract
     .owner('0x00000000000000000000000000000000')


### PR DESCRIPTION

## Demo

https://www.youtube.com/watch?v=v_UlLSgmm0M

## Complete tasks

- Show migrate button if the name is registered by old resolver
- Call `transferRegistrars` when migration button is pressed.

## Outstanding tasks

- Remove hardcoded registrars addresses (pending on [EIP-1844 work to be updated into `resolver` package](https://discuss.ens.domains/t/ethregistrarcontolloer-address/875))
- Do not show `Migrate` button if the old resolver locking period (28 days) has not passed (pending on  new `ethregistrar ` package to include [this PR](https://github.com/ensdomains/ethregistrar/pull/23/files))
- Incorporate with new design
- "release" button after migration period ends