### PR TITLE
Set interface implementer

### DIFF
--- a/src/api/ens.js
+++ b/src/api/ens.js
@@ -2,7 +2,7 @@ import _ from 'lodash'
 import getWeb3, { getWeb3Read, getNetworkId } from './web3'
 import { abi as ensContract } from '@ensdomains/ens/build/contracts/ENS.json'
 import { abi as reverseRegistrarContract } from '@ensdomains/ens/build/contracts/ReverseRegistrar.json'
-import { abi as resolverContract } from '@ensdomains/resolver/build/contracts/Resolver.json'
+import { abi as resolverContract } from '@ensdomains/resolver/build/contracts/PublicResolver.json'
 import { abi as fifsRegistrarContract } from '@ensdomains/ens/build/contracts/FIFSRegistrar.json'
 import { abi as testRegistrarContract } from '@ensdomains/ens/build/contracts/TestRegistrar.json'
 

--- a/src/api/registrar.js
+++ b/src/api/registrar.js
@@ -25,7 +25,7 @@ export const getLegacyAuctionRegistrar = async () => {
     const { Resolver } = await getEthResolver()
     let legacyAuctionRegistrarAddress = await Resolver.interfaceImplementer(
       await getNamehash('eth'),
-      web3.utils.sha3('legacyRegistrar').slice(0, 10),
+      web3.utils.sha3('transferRegistrars').slice(0, 10),
     ).call()
 
     ethRegistrar = new web3.eth.Contract(
@@ -88,7 +88,7 @@ export const getPermanentRegistrarController = async () => {
     const { Resolver } = await getEthResolver()
     let controllerAddress = await Resolver.interfaceImplementer(
       await getNamehash('eth'),
-      web3.utils.sha3('registrarController').slice(0, 10),
+      web3.utils.sha3('register').slice(0, 10),
     ).call()
     permanentRegistrarController = new web3.eth.Contract(
       permanentRegistrarControllerContract,

--- a/src/constants/interfaces.json
+++ b/src/constants/interfaces.json
@@ -1,0 +1,5 @@
+{
+  "legacyRegistrar": "0x7ba18ba1",
+  "permanentRegistrar": "0x018fac06",
+  "baseRegistrar": "0x6ccb2df4"
+}

--- a/src/testing-utils/deployENS.js
+++ b/src/testing-utils/deployENS.js
@@ -1,4 +1,8 @@
 const util = require('util')
+const {
+  legacyRegistrar: legacyRegistrarInterfaceId,
+  permanentRegistrar: permanentRegistrarInterfaceId
+} = require('../constants/interfaces')
 const DAYS = 24 * 60 * 60
 const VALUE = 28 * DAYS + 1
 
@@ -354,36 +358,31 @@ module.exports = async function deployENS({ web3, accounts }) {
   console.log('Controller deployed at: ', controller._address)
 
   await ensContract
-    .setSubnodeOwner(
-      '0x00000000000000000000000000000000',
-      tldHash,
-      accounts[0]
-    )
+    .setSubnodeOwner('0x00000000000000000000000000000000', tldHash, accounts[0])
     .send({
       from: accounts[0]
     })
 
-  await resolverContract.setAuthorisation(
-      namehash('eth'),
-      accounts[0],
-      true
-    )
+  await resolverContract
+    .setAuthorisation(namehash('eth'), accounts[0], true)
     .send({
       from: accounts[0]
-    })  
+    })
 
-  await resolverContract.setInterface(
+  await resolverContract
+    .setInterface(
       namehash('eth'),
-      web3.utils.sha3('transferRegistrars').slice(0, 10),
+      legacyRegistrarInterfaceId,
       legacyAuctionRegistrar._address
     )
     .send({
       from: accounts[0]
     })
 
-  await resolverContract.setInterface(
+  await resolverContract
+    .setInterface(
       namehash('eth'),
-      web3.utils.sha3('register').slice(0, 10),
+      permanentRegistrarInterfaceId,
       controller._address
     )
     .send({
@@ -517,7 +516,7 @@ module.exports = async function deployENS({ web3, accounts }) {
     .send({ from: accounts[2], gas: 1000000 })
 
   await mine(web3)
-  let current = await web3.eth.getBlock('latest');
+  let current = await web3.eth.getBlock('latest')
   console.log(`The current time is ${new Date(current.timestamp * 1000)}`)
 
   return {

--- a/src/testing-utils/deployENS.js
+++ b/src/testing-utils/deployENS.js
@@ -372,7 +372,7 @@ module.exports = async function deployENS({ web3, accounts }) {
     })  
   await resolverContract.setInterface(
       namehash('eth'),
-      web3.utils.sha3('legacyRegistrar').slice(0, 10),
+      web3.utils.sha3('transferRegistrars').slice(0, 10),
       legacyAuctionRegistrar._address
     )
     .send({
@@ -381,7 +381,7 @@ module.exports = async function deployENS({ web3, accounts }) {
 
   await resolverContract.setInterface(
       namehash('eth'),
-      web3.utils.sha3('registrarController').slice(0, 10),
+      web3.utils.sha3('register').slice(0, 10),
       controller._address
     )
     .send({

--- a/src/testing-utils/deployENS.js
+++ b/src/testing-utils/deployENS.js
@@ -353,6 +353,41 @@ module.exports = async function deployENS({ web3, accounts }) {
   console.log('Base registrar deployed at: ', baseRegistrar._address)
   console.log('Controller deployed at: ', controller._address)
 
+  await ensContract
+    .setSubnodeOwner(
+      '0x00000000000000000000000000000000',
+      tldHash,
+      accounts[0]
+    )
+    .send({
+      from: accounts[0]
+    })
+  await resolverContract.setAuthorisation(
+      namehash('eth'),
+      accounts[0],
+      true
+    )
+    .send({
+      from: accounts[0]
+    })  
+  await resolverContract.setInterface(
+      namehash('eth'),
+      web3.utils.sha3('legacyRegistrar').slice(0, 10),
+      legacyAuctionRegistrar._address
+    )
+    .send({
+      from: accounts[0]
+    })
+
+  await resolverContract.setInterface(
+      namehash('eth'),
+      web3.utils.sha3('registrarController').slice(0, 10),
+      controller._address
+    )
+    .send({
+      from: accounts[0]
+    })
+
   /* Set the permanent registrar contract as the owner of .eth */
   await ensContract
     .setSubnodeOwner(

--- a/src/testing-utils/deployENS.js
+++ b/src/testing-utils/deployENS.js
@@ -362,6 +362,7 @@ module.exports = async function deployENS({ web3, accounts }) {
     .send({
       from: accounts[0]
     })
+
   await resolverContract.setAuthorisation(
       namehash('eth'),
       accounts[0],
@@ -370,6 +371,7 @@ module.exports = async function deployENS({ web3, accounts }) {
     .send({
       from: accounts[0]
     })  
+
   await resolverContract.setInterface(
       namehash('eth'),
       web3.utils.sha3('transferRegistrars').slice(0, 10),
@@ -398,6 +400,7 @@ module.exports = async function deployENS({ web3, accounts }) {
     .send({
       from: accounts[0]
     })
+
   console.log('Add controller to base registrar')
   await baseRegistrarContract
     .addController(controller._address)

--- a/src/testing-utils/preTest.mjs
+++ b/src/testing-utils/preTest.mjs
@@ -44,16 +44,10 @@ async function init() {
   fs.writeFileSync('./cypress.env.json', JSON.stringify(addresses))
   fs.writeFile(
     './.env.local',
-    `REACT_APP_ENS_ADDRESS=${ensAddress}\nREACT_APP_CONTROLLER_ADDRESS=${controllerAddress}\nREACT_APP_AUCTION_REGISTRAR_ADDRESS=${legacyAuctionRegistrarAddress}`,
+    `REACT_APP_ENS_ADDRESS=${ensAddress}`,
     err => {
       if (err) throw err
       console.log(`Successfully wrote ENS address ${ensAddress} to .env.local`)
-      console.log(
-        `Successfully wrote controller address ${controllerAddress} to .env.local`
-      )
-      console.log(
-        `Successfully wrote legacy Auction Registrar address ${legacyAuctionRegistrarAddress} to .env.local`
-      )
     }
   )
 }


### PR DESCRIPTION
@Arachnid 

I set interface signature of the legacy auction registrar as `transferRegistrars` and the new registrar controller as `register` (no need to register base registrar as it is the owner of `.eth`). Let me know if you prefer to use other names for your public net deployments.