### PR TITLE
Do not show content nor contenttype if the resolver does not support …

### DIFF
--- a/src/api/registry.js
+++ b/src/api/registry.js
@@ -98,7 +98,7 @@ export async function getContent(name) {
   } catch (e) {
     const message =
       'Error getting content on the resolver contract, are you sure the resolver address is a resolver contract?'
-    console.warn(message)
+    console.warn(message, e)
     return { value: message, contentType: 'error' }
   }
 }

--- a/src/components/SingleName/RecordsItem.js
+++ b/src/components/SingleName/RecordsItem.js
@@ -227,24 +227,25 @@ const Editable = ({
 class RecordItem extends Component {
   _renderViewOnly() {
     const { keyName, value, type, domain, account } = this.props
-    return (
+    const {name, contentType} = domain
+    return ( (keyName !== 'Address' && contentType === 'error') ? '':(
       <RecordsItem>
-        <RecordsContent>
-          <RecordsKey>{keyName}</RecordsKey>
-          <RecordsValue>
-            {type === 'address' ? (
-              <EtherScanLink address={value}>{value}</EtherScanLink>
-            ) : (
-              <ContentHashLink value={value} contentType={domain.contentType} />
-            )}
-          </RecordsValue>
-        </RecordsContent>
-        {keyName === 'Address' &&
-          value.toLowerCase() === account.toLowerCase() && (
-            <AddReverseRecord account={account} name={domain.name} />
-          )}
+      <RecordsContent>
+        <RecordsKey>{keyName}</RecordsKey>
+        <RecordsValue>
+          {type === 'address' ? (
+            <EtherScanLink address={value}>{value}</EtherScanLink>
+          ) : 
+            <ContentHashLink value={value} contentType={contentType} />
+          }
+        </RecordsValue>
+      </RecordsContent>
+      {keyName === 'Address' &&
+        value.toLowerCase() === account.toLowerCase() && (
+          <AddReverseRecord account={account} name={name} />
+        )}
       </RecordsItem>
-    )
+    ))
   }
   render() {
     const { isOwner } = this.props


### PR DESCRIPTION
This change is to fix https://github.com/ensdomains/ens-app/issues/147

The error happens when a resolver (eg: https://etherscan.io/address/0x074d58C0a0903d4C7DB9388205232602a0bF9Bf0#code ) does not have `content` nor `setContent` function. The solution is not to show content/contethash field 