### PR TITLE
Fix cropped info icon

### DIFF
--- a/src/components/Icons/Info.js
+++ b/src/components/Icons/Info.js
@@ -6,7 +6,7 @@ class Info extends Component {
     const { className, onClick, onMouseOver, onMouseLeave} = this.props
 
     return (
-      <InfoContainer width="19" height="17"
+      <InfoContainer width="18" height="18"
         className={className}
         onClick={onClick}
         onMouseOver={onMouseOver}

--- a/src/components/SingleName/DetailsItemEditable.js
+++ b/src/components/SingleName/DetailsItemEditable.js
@@ -19,7 +19,14 @@ import Pencil from '../Forms/Pencil'
 import Info from '../Icons/Info'
 import DefaultPendingTx from '../PendingTx'
 
-const EtherScanLink = styled(DefaultEtherScanLink)``
+// without inline-block, i icon will be hidden as the width gets narrower
+const EtherScanLinkContainer = styled('div')`
+  display: inline-block;
+`
+
+const EtherScanLink = styled(DefaultEtherScanLink)`
+  display:flex;
+  `
 
 const EditButton = styled(Button)`
   width: 130px;
@@ -39,11 +46,11 @@ const DetailsContent = styled('div')`
   justify-content: flex-start;
   position: relative;
   flex-direction: column;
-  width: 100%;
   ${({ editing }) => editing && 'margin-bottom: 30px'};
   transition: 0.3s;
   ${mq.small`
     flex-direction: row;
+    padding-right:150px;
   `}
 `
 
@@ -142,6 +149,7 @@ const Editable = ({
               data-testid={`details-value-${keyName.toLowerCase()}`}
             >
               {type === 'address' ? (
+                <EtherScanLinkContainer>
                 <EtherScanLink address={value}>
                   <SingleNameBlockies address={value} imageSize={24} />
                   { keyName === 'Resolver' && domain.contentType === 'oldcontent' ? (
@@ -169,6 +177,7 @@ const Editable = ({
                   ): null }
                   {value}
                 </EtherScanLink>
+                </EtherScanLinkContainer>
               ) : (
                 value
               )}


### PR DESCRIPTION
- Fix cropped icon
- Align round icons and address list to come in centre
- (Ellipsis is not working)

<img width="566" alt="Screenshot 2019-04-16 at 13 09 21" src="https://user-images.githubusercontent.com/2630/56208416-fcff1c80-6048-11e9-9c6e-4dbe54af0525.png">
