### PR TITLE
Point to Resolver, not PublicResolver

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "@ensdomains/ens": "^0.3.3",
     "@ensdomains/ens-022": "npm:@ensdomains/ens@0.2.2",
     "@ensdomains/ethregistrar": "^1.1.4",
-    "@ensdomains/resolver": "^0.1.1",
+    "@ensdomains/resolver": "^0.1.4",
     "apollo-cache-inmemory": "^1.2.9",
     "apollo-client": "^2.4.5",
     "apollo-link": "^1.2.2",

--- a/src/api/ens.js
+++ b/src/api/ens.js
@@ -3,22 +3,9 @@ import getWeb3, { getWeb3Read, getNetworkId } from './web3'
 import { hash, normalize } from 'eth-ens-namehash'
 import { abi as ensContract } from '@ensdomains/ens/build/contracts/ENS.json'
 import { abi as reverseRegistrarContract } from '@ensdomains/ens/build/contracts/ReverseRegistrar.json'
-import { abi as resolverContract } from '@ensdomains/resolver/build/contracts/PublicResolver.json'
-import { abi as oldResolverContract } from '@ensdomains/ens-022/build/contracts/PublicResolver.json'
+import { abi as resolverContract } from '@ensdomains/resolver/build/contracts/Resolver.json'
 import { abi as fifsRegistrarContract } from '@ensdomains/ens/build/contracts/FIFSRegistrar.json'
 import { abi as testRegistrarContract } from '@ensdomains/ens/build/contracts/TestRegistrar.json'
-
-oldResolverContract.forEach((old, i) => {
-  if (
-    !resolverContract
-      .map(n => {
-        return n.name
-      })
-      .includes(old.name)
-  ) {
-    resolverContract.push(old)
-  }
-})
 
 var contracts = {
   1: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -993,10 +993,10 @@
     truffle "^5.0.5"
     web3-utils "^1.0.0-beta.48"
 
-"@ensdomains/resolver@^0.1.1":
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/@ensdomains/resolver/-/resolver-0.1.3.tgz#e347031dc08f822d39364585e9f9ab2ac1147621"
-  integrity sha512-nYbvYDSdNBYznGRPMcV3lMJ36VTnNwDb0gpb31bjIeRjQXoYuizBmE3540uQ2fWwxIlM4viIEBrQh4u39iDbPw==
+"@ensdomains/resolver@^0.1.4":
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/@ensdomains/resolver/-/resolver-0.1.4.tgz#5933b94d1b24521d08153a09c60a939f7cc9543b"
+  integrity sha512-hF4lm8tcao8WWowJEBihii53C3/wDDT2vz+1WKhAJLMKAKyBjz2DQTGuIJE0aPGzFKl8GFR6Be/OxqF6U9reGA==
 
 "@mrmlnc/readdir-enhanced@^2.2.1":
   version "2.2.1"


### PR DESCRIPTION
@jefflau I think the reason you had issue was that somehow `build/contracts/Resolver.json` was reverted back to `build/contracts/PublicResolver.json` at some point in your branch. Otherwise it would have been failing on live.