### PR TITLE
Disable register button on readOnly

### DIFF
--- a/src/api/rootResolver.js
+++ b/src/api/rootResolver.js
@@ -1,4 +1,4 @@
-import getWeb3, { getAccounts, getNetworkId } from './web3'
+import getWeb3, { getAccounts, getNetworkId, isReadOnly } from './web3'
 import { getAddr } from './registry'
 import merge from 'lodash/merge'
 import fifsResolvers, {
@@ -55,10 +55,11 @@ const resolvers = {
     }
   },
   Query: {
-    web3: async (_, variables, context) => {
+    web3: async () => {
       try {
         return {
           ...(await getWeb3()),
+          isReadOnly: isReadOnly(),
           __typename: 'Web3'
         }
       } catch (e) {
@@ -88,7 +89,6 @@ const resolvers = {
       const data = {
         error: errorObj
       }
-      console.log(data)
       cache.writeData({ data })
       return errorObj
     }

--- a/src/api/web3.js
+++ b/src/api/web3.js
@@ -126,7 +126,7 @@ export async function getNetworkId() {
 
 export async function getBlock() {
   const web3 = await getWeb3()
-  let block =  await web3.eth.getBlock('latest');
+  let block = await web3.eth.getBlock('latest')
   return {
     number: block.number,
     timestamp: block.timestamp

--- a/src/components/Forms/Button.js
+++ b/src/components/Forms/Button.js
@@ -111,7 +111,6 @@ const Button = props => {
       className={className}
       type={type}
       onClick={onClick}
-      disabled={type === 'disabled'}
       {...props}
     >
       {children}

--- a/src/components/SingleName/Name.js
+++ b/src/components/SingleName/Name.js
@@ -81,17 +81,23 @@ function isRegistrationOpen(domain, isDeedOwner) {
   return parent === 'eth' && !isDeedOwner && available
 }
 
+function isOwnerOfDomain(domain, account) {
+  if (domain.owner !== EMPTY_ADDRESS) {
+    return domain.owner.toLowerCase() === account.toLowerCase()
+  }
+  return false
+}
+
 function Name({ details: domain, name, pathname, refetch }) {
   const smallBP = useMediaMin('small')
   const percentDone = 0
+
   return (
     <QueryAccount>
       {({ account }) => {
-        let isOwner = false
-        if (domain.owner !== EMPTY_ADDRESS) {
-          isOwner = domain.owner.toLowerCase() === account.toLowerCase()
-        }
+        const isOwner = isOwnerOfDomain(domain, account)
         const isDeedOwner = domain.deedOwner === account
+
         return (
           <NameContainer state={isOwner ? 'Yours' : domain.state}>
             <TopBar percentDone={percentDone}>
@@ -116,6 +122,7 @@ function Name({ details: domain, name, pathname, refetch }) {
                 domain={domain}
                 pathname={pathname}
                 refetch={refetch}
+                readOnly={account === EMPTY_ADDRESS}
               />
             ) : (
               <NameDetails

--- a/src/components/SingleName/NameRegister/CTA.js
+++ b/src/components/SingleName/NameRegister/CTA.js
@@ -4,6 +4,7 @@ import { Mutation } from 'react-apollo'
 
 import { COMMIT, REGISTER } from '../../../graphql/mutations'
 
+import Tooltip from 'components/Tooltip/Tooltip'
 import PendingTx from '../../PendingTx'
 import Button from '../../Forms/Button'
 import { ReactComponent as DefaultPencil } from '../../Icons/SmallPencil.svg'
@@ -37,7 +38,8 @@ function getCTA({
   setTxHash,
   setTimerRunning,
   isAboveMinDuration,
-  refetch
+  refetch,
+  readOnly
 }) {
   const CTAs = {
     PRICE_DECISION: (
@@ -50,10 +52,35 @@ function getCTA({
         }}
       >
         {mutate =>
-          isAboveMinDuration ? (
+          isAboveMinDuration && !readOnly ? (
             <Button data-testid="request-register-button" onClick={mutate}>
               Request to register
             </Button>
+          ) : readOnly ? (
+            <Tooltip
+              text="<p>You are not connected to a web3 browser. Please connect to a web3 browser and try again</p>"
+              position="top"
+              border={true}
+              offset={{ left: -30, top: 10 }}
+            >
+              {({ tooltipElement, showTooltip, hideTooltip }) => {
+                return (
+                  <Button
+                    data-testid="request-register-button"
+                    type="disabled"
+                    onMouseOver={() => {
+                      showTooltip()
+                    }}
+                    onMouseLeave={() => {
+                      hideTooltip()
+                    }}
+                  >
+                    Request to register
+                    {tooltipElement}
+                  </Button>
+                )
+              }}
+            </Tooltip>
           ) : (
             <Button data-testid="request-register-button" type="disabled">
               Request to register
@@ -119,12 +146,12 @@ function getCTA({
 const CTA = ({
   step,
   incrementStep,
-  decrementStep,
   duration,
   label,
   setTimerRunning,
   isAboveMinDuration,
-  refetch
+  refetch,
+  readOnly
 }) => {
   const [txHash, setTxHash] = useState(undefined)
   return (
@@ -138,7 +165,8 @@ const CTA = ({
         setTxHash,
         setTimerRunning,
         isAboveMinDuration,
-        refetch
+        refetch,
+        readOnly
       })}
     </CTAContainer>
   )

--- a/src/components/SingleName/NameRegister/NameRegister.js
+++ b/src/components/SingleName/NameRegister/NameRegister.js
@@ -18,7 +18,7 @@ const NameRegisterContainer = styled('div')`
   padding: 20px 40px;
 `
 
-const NameRegister = ({ domain, waitTime, refetch }) => {
+const NameRegister = ({ domain, waitTime, refetch, readOnly }) => {
   const [step, dispatch] = useReducer(
     registerReducer,
     registerMachine.initialState
@@ -29,6 +29,8 @@ const NameRegister = ({ domain, waitTime, refetch }) => {
   const [secondsPassed, setSecondsPassed] = useState(0)
   const [timerRunning, setTimerRunning] = useState(false)
   const { loading: ethUsdPriceLoading, price: ethUsdPrice } = useEthPrice()
+
+  console.log(readOnly)
 
   useInterval(
     () => {
@@ -80,6 +82,7 @@ const NameRegister = ({ domain, waitTime, refetch }) => {
         setTimerRunning={setTimerRunning}
         refetch={refetch}
         isAboveMinDuration={isAboveMinDuration}
+        readOnly={readOnly}
       />
     </NameRegisterContainer>
   )

--- a/src/graphql/queries.js
+++ b/src/graphql/queries.js
@@ -5,6 +5,7 @@ export const GET_WEB3 = gql`
   query web3 {
     web3 @client {
       accounts
+      isReadOnly
     }
   }
 `


### PR DESCRIPTION
Closes #208 

This is ticket is actually incorrect as the default readOnly env was mainnet, which does not have the permanent registrar up yet. When connecting to ropsten, it will actually display the register button however it fails because there is no wallet available. Therefore this PR is to disable the register button and add a tooltip informing the user they are not connected to a web3 browser