### PR TITLE
add notification polyfill for ios safari

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "idna-uts46-hx": "2.3.1",
     "lodash": "^4.17.10",
     "moment": "^2.22.2",
+    "notification-polyfill": "^1.0.0",
     "react": "16.7.0-alpha.0",
     "react-add-to-calendar": "^0.1.5",
     "react-apollo": "^2.1.2",

--- a/src/components/SingleName/NameRegister/notification.js
+++ b/src/components/SingleName/NameRegister/notification.js
@@ -1,3 +1,5 @@
+import 'notification-polyfill'
+
 export function sendNotification(message = 'Hi there') {
   // Let's check if the browser supports notifications
   if (!('Notification' in window)) {

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,6 @@
 import React from 'react'
 import ReactDOM from 'react-dom'
 import { ApolloProvider } from 'react-apollo'
-import 'notification-polyfill'
 
 import App from 'App'
 import setupWeb3 from 'api/web3'

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import ReactDOM from 'react-dom'
 import { ApolloProvider } from 'react-apollo'
+import 'notification-polyfill'
 
 import App from 'App'
 import setupWeb3 from 'api/web3'

--- a/yarn.lock
+++ b/yarn.lock
@@ -8616,6 +8616,11 @@ normalize-url@^3.0.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/normalize-url/-/normalize-url-3.3.0.tgz#b2e1c4dc4f7c6d57743df733a4f5978d18650559"
 
+notification-polyfill@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/notification-polyfill/-/notification-polyfill-1.0.0.tgz#6e5f0efc2dd8e2db17c0510fa4331c40c9579d9a"
+  integrity sha1-bl8O/C3Y4tsXwFEPpDMcQMlXnZo=
+
 npm-bundled@^1.0.1:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/npm-bundled/-/npm-bundled-1.0.5.tgz#3c1732b7ba936b3a10325aef616467c0ccbcc979"


### PR DESCRIPTION
https://caniuse.com/#search=notification

on the iOS device, the Global Object `Notification` is unavailable yet.
so we need to add a polyfill to resolve this problem.