### PR TITLE
fix: some provider not support eth_subscrbe

### DIFF
--- a/src/api/web3.js
+++ b/src/api/web3.js
@@ -5,6 +5,14 @@ let web3Read
 let readOnly = false
 
 export default async function getWeb3(customProvider) {
+
+  /**
+   * NOTE: imToken ethereum provider has `on` method, but don't support `eth_subscrbe` now.
+   */
+  if (window.imToken && window.ethereum && !window.ethereum.supportsSubscriptions) {
+    window.ethereum.on = null
+  }
+
   if (web3) {
     return web3
   }


### PR DESCRIPTION
Currently, some provider doesn't support `subscription` but has `on` method (for the EIP1193 eventEmitter).

in web3.js 1.0.0-beta.34, if the provider has `on` method, it will not fallback to receipt polling.
it just sends `eth_subscribe` RPC request, so if the provider or node doesn't support `subscription`, the `.on('receipt'` will never get fired.
![image](https://user-images.githubusercontent.com/990255/57567921-e7480180-7412-11e9-985c-c9ba0db7c9c8.png)

in the latest version of web3.js, the judge condition is changed to:
![image](https://user-images.githubusercontent.com/990255/57567955-53c30080-7413-11e9-9f3e-322c5177a71e.png)

Right now, we only can avoid the condition check by resetting the `on` method of the provider.

while Metamask doesn't have this problem, cause they don't send `eth_subscribe` request to node server, the polling every block, and fire the event by themselves.

This is a temporary solution, we will fix it in the future.