### PR TITLE
Set type to unsupported

### DIFF
--- a/src/routes/SingleName.js
+++ b/src/routes/SingleName.js
@@ -32,15 +32,15 @@ function SingleName({
       } else {
         _type = parseSearchTerm(searchTerm)
       }
-      setType(_type)
       if (_type === 'supported' || _type === 'tld') {
         setValid(true)
       } else {
+        _type = 'unsupported'
         setValid(false)
       }
+      setType(_type)
     }
   }, [searchTerm])
-
   if (valid) {
     return (
       <Query query={GET_SINGLE_NAME} variables={{ name }}>


### PR DESCRIPTION
Looks like I broke this when I (or was it Jeff? I can't remember) refactored to normalise the name so if people go something  like http://manager.ens.domains/name/aaaa it was showing blank page rather than displaying `Domain tld unsupported. aaaa is not currently a support tld.`