### PR TITLE
Show parsed search result

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "graphql-tag": "2.9.1",
     "graphql-tools": "^2.23.1",
     "gsap": "^2.0.1",
-    "idna-uts46-hx": "2.3.1",
     "lodash": "^4.17.10",
     "moment": "^2.22.2",
     "notification-polyfill": "^1.0.0",

--- a/src/routes/SearchResults.js
+++ b/src/routes/SearchResults.js
@@ -3,7 +3,7 @@ import DomainInfo from '../components/SearchName/DomainInfo'
 import { SubDomainStateFields } from '../graphql/fragments'
 import { Mutation } from 'react-apollo'
 import gql from 'graphql-tag'
-import { parseSearchTerm } from '../utils/utils'
+import { validateName, parseSearchTerm } from '../utils/utils'
 import SearchErrors from '../components/SearchErrors/SearchErrors'
 import { isShortName } from '../utils/utils'
 
@@ -20,7 +20,9 @@ const GET_SUBDOMAIN_AVAILABILITY = gql`
 class Results extends React.Component {
   state = {
     errors: [],
-    errorType: ''
+    errorType: '',
+    type: null,
+    parsed: null
   }
   checkValidity = () => {
     const { searchTerm, getSubDomainAvailability } = this.props
@@ -30,6 +32,12 @@ class Results extends React.Component {
     })
     const type = parseSearchTerm(searchTerm)
 
+    if (!['unsupported', 'invalid'].includes(type)) {
+      const parsed = validateName(searchTerm)
+      this.setState({
+        parsed
+      })
+    }
     document.title = `ENS Search: ${searchTerm}`
 
     if (type === 'unsupported') {
@@ -79,12 +87,16 @@ class Results extends React.Component {
         />
       )
     }
-    return (
-      <Fragment>
-        <DomainInfo searchTerm={searchTerm} />
-        {/* <SubDomainResults searchTerm={searchTerm} /> */}
-      </Fragment>
-    )
+    if (this.state.parsed) {
+      return (
+        <Fragment>
+          <DomainInfo searchTerm={this.state.parsed} />
+          {/* <SubDomainResults searchTerm={searchTerm} /> */}
+        </Fragment>
+      )
+    } else {
+      return ''
+    }
   }
 }
 

--- a/src/routes/SearchResults.js
+++ b/src/routes/SearchResults.js
@@ -21,7 +21,6 @@ class Results extends React.Component {
   state = {
     errors: [],
     errorType: '',
-    type: null,
     parsed: null
   }
   checkValidity = () => {

--- a/src/routes/SearchResults.js
+++ b/src/routes/SearchResults.js
@@ -25,14 +25,14 @@ class Results extends React.Component {
   }
   checkValidity = () => {
     const { searchTerm, getSubDomainAvailability } = this.props
-
+    let parsed
     this.setState({
       errors: []
     })
     const type = parseSearchTerm(searchTerm)
 
     if (!['unsupported', 'invalid'].includes(type)) {
-      const parsed = validateName(searchTerm)
+      parsed = validateName(searchTerm)
       this.setState({
         parsed
       })
@@ -47,7 +47,7 @@ class Results extends React.Component {
       this.setState({
         errors: ['domainMalformed']
       })
-    } else if (isShortName(searchTerm)) {
+    } else if (isShortName(parsed || searchTerm)) {
       this.setState({
         errors: ['tooShort']
       })

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -1,7 +1,8 @@
 import { getNetworkId } from '../api/web3'
-import uts46 from 'idna-uts46-hx'
 import { addressUtils } from '@0xproject/utils'
 import tlds from '../constants/tlds.json'
+import { normalize } from 'eth-ens-namehash'
+
 //import { checkLabelHash } from '../updaters/preImageDB'
 
 export const uniq = (a, param) =>
@@ -52,10 +53,7 @@ export function validateName(name) {
   const hasEmptyLabels = name.split('.').filter(e => e.length < 1).length > 0
   if (hasEmptyLabels) throw new Error('Domain cannot have empty labels')
   try {
-    return uts46.toUnicode(name, {
-      useStd3ASCII: true,
-      transitional: false
-    })
+    return normalize(name)
   } catch (e) {
     throw e
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6426,7 +6426,7 @@ identity-obj-proxy@3.0.0:
   dependencies:
     harmony-reflect "^1.4.6"
 
-idna-uts46-hx@2.3.1, idna-uts46-hx@^2.3.1:
+idna-uts46-hx@^2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/idna-uts46-hx/-/idna-uts46-hx-2.3.1.tgz#a1dc5c4df37eee522bf66d969cc980e00e8711f9"
   dependencies:


### PR DESCRIPTION
This is to partly fix [this](https://github.com/ensdomains/ens-app/issues/282)

## Before

- Searching 👩‍❤️‍👨👩‍❤️‍👨displays unnormalised format (👩‍❤️‍👨👩‍❤️‍👨)
- `/search/👩‍❤️‍👨1` was allowed as it was counted as 7 (6 char + 1)
- `/name/👩‍❤️‍👨1.eth` was showing `unsupported tld` error.

<img width="931" alt="Screenshot 2019-05-15 at 20 50 13" src="https://user-images.githubusercontent.com/2630/57804651-19c76680-7753-11e9-9185-79e1a8f52723.png">


## After (you can test this PR version at http://imaginary-summer.surge.sh/ )

- It should reformat to normalised version (👩‍❤‍👨👩‍❤‍👨)
- `/search/👩‍❤️‍👨1` and `/name/👩‍❤️‍👨1.eth` should show `name too short` but `/search/👩‍❤️‍👨12` and `/search/👩‍❤️‍👨12.eth` should be ok.
- Replace `uts46` with `normalise` function of `ethereum-ens` per [Nick's suggestion](https://github.com/ensdomains/ens-app/issues/282#issuecomment-492809999)

<img width="540" alt="Screenshot 2019-05-15 at 20 49 11" src="https://user-images.githubusercontent.com/2630/57804605-f8ff1100-7752-11e9-8b96-a6f27e9767ed.png">

## Out of scope (for next PR)

Redirect to normalised URL
