### PR TITLE
Show parsed search result (#324)

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "graphql-tag": "2.9.1",
     "graphql-tools": "^2.23.1",
     "gsap": "^2.0.1",
-    "idna-uts46-hx": "2.3.1",
     "lodash": "^4.17.10",
     "moment": "^2.22.2",
     "notification-polyfill": "^1.0.0",

--- a/src/routes/SearchResults.js
+++ b/src/routes/SearchResults.js
@@ -3,7 +3,7 @@ import DomainInfo from '../components/SearchName/DomainInfo'
 import { SubDomainStateFields } from '../graphql/fragments'
 import { Mutation } from 'react-apollo'
 import gql from 'graphql-tag'
-import { parseSearchTerm } from '../utils/utils'
+import { validateName, parseSearchTerm } from '../utils/utils'
 import SearchErrors from '../components/SearchErrors/SearchErrors'
 import { isShortName } from '../utils/utils'
 
@@ -20,16 +20,23 @@ const GET_SUBDOMAIN_AVAILABILITY = gql`
 class Results extends React.Component {
   state = {
     errors: [],
-    errorType: ''
+    errorType: '',
+    parsed: null
   }
   checkValidity = () => {
     const { searchTerm, getSubDomainAvailability } = this.props
-
+    let parsed
     this.setState({
       errors: []
     })
     const type = parseSearchTerm(searchTerm)
 
+    if (!['unsupported', 'invalid'].includes(type)) {
+      parsed = validateName(searchTerm)
+      this.setState({
+        parsed
+      })
+    }
     document.title = `ENS Search: ${searchTerm}`
 
     if (type === 'unsupported') {
@@ -40,7 +47,7 @@ class Results extends React.Component {
       this.setState({
         errors: ['domainMalformed']
       })
-    } else if (isShortName(searchTerm)) {
+    } else if (isShortName(parsed || searchTerm)) {
       this.setState({
         errors: ['tooShort']
       })
@@ -79,12 +86,16 @@ class Results extends React.Component {
         />
       )
     }
-    return (
-      <Fragment>
-        <DomainInfo searchTerm={searchTerm} />
-        {/* <SubDomainResults searchTerm={searchTerm} /> */}
-      </Fragment>
-    )
+    if (this.state.parsed) {
+      return (
+        <Fragment>
+          <DomainInfo searchTerm={this.state.parsed} />
+          {/* <SubDomainResults searchTerm={searchTerm} /> */}
+        </Fragment>
+      )
+    } else {
+      return ''
+    }
   }
 }
 

--- a/src/routes/SingleName.js
+++ b/src/routes/SingleName.js
@@ -39,7 +39,9 @@ function SingleName({
       if (_type === 'supported' || _type === 'tld') {
         setValid(true)
       } else {
-        _type = 'unsupported'
+        if (_type == !'short') {
+          _type = 'unsupported'
+        }
         setValid(false)
       }
       setType(_type)

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -1,7 +1,8 @@
 import { getNetworkId } from '../api/web3'
-import uts46 from 'idna-uts46-hx'
 import { addressUtils } from '@0xproject/utils'
 import tlds from '../constants/tlds.json'
+import { normalize } from 'eth-ens-namehash'
+
 //import { checkLabelHash } from '../updaters/preImageDB'
 
 export const uniq = (a, param) =>
@@ -52,10 +53,7 @@ export function validateName(name) {
   const hasEmptyLabels = name.split('.').filter(e => e.length < 1).length > 0
   if (hasEmptyLabels) throw new Error('Domain cannot have empty labels')
   try {
-    return uts46.toUnicode(name, {
-      useStd3ASCII: true,
-      transitional: false
-    })
+    return normalize(name)
   } catch (e) {
     throw e
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6426,7 +6426,7 @@ identity-obj-proxy@3.0.0:
   dependencies:
     harmony-reflect "^1.4.6"
 
-idna-uts46-hx@2.3.1, idna-uts46-hx@^2.3.1:
+idna-uts46-hx@^2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/idna-uts46-hx/-/idna-uts46-hx-2.3.1.tgz#a1dc5c4df37eee522bf66d969cc980e00e8711f9"
   dependencies:


### PR DESCRIPTION
* Fixes #282 (no redirection yet)
* Check length against normalised unicode
* Replace uts46 with eth-ens-namehash
* Fix problem of displaying 'Domain tld unsupported. eth is not currently a support tld.' for a short name