### PR TITLE
Fix: Cannot read property 'mutate' of undefined in Opera Browser

### DIFF
--- a/src/apolloClient.js
+++ b/src/apolloClient.js
@@ -27,7 +27,7 @@ async function getNetwork() {
     network = window.ethereum.networkVersion
   } else if (window.web3) {
     network = await new Promise((resolve, reject) => {
-      window.version.web3.getNetwork((err, network) => {
+      window.web3.version.getNetwork((err, network) => {
         resolve(network)
       })
     })

--- a/src/components/hooks.js
+++ b/src/components/hooks.js
@@ -103,10 +103,12 @@ export function useEthPrice(enabled = true) {
 
   useEffect(() => {
     if (enabled) {
-      getEtherPrice().then(res => {
-        setPrice(res.result.ethusd)
-        setLoading(false)
-      })
+      getEtherPrice()
+        .then(res => {
+          setPrice(res.result.ethusd)
+          setLoading(false)
+        })
+        .catch(() => '') // ignore error
     }
   }, [enabled])
 

--- a/src/index.js
+++ b/src/index.js
@@ -14,20 +14,24 @@ window.addEventListener('load', async () => {
   let client
   try {
     client = await setupClient()
-    await setupENS({ reloadOnAccountsChange: true })
+    try {
+      await setupENS({ reloadOnAccountsChange: true })
+    } catch (e) {
+      console.warn('setupENS', e)
+      await client.mutate({
+        mutation: SET_ERROR,
+        variables: { message: e.message }
+      })
+    }
+    ReactDOM.render(
+      <ApolloProvider client={client}>
+        <GlobalStateProvider>
+          <App />
+        </GlobalStateProvider>
+      </ApolloProvider>,
+      document.getElementById('root')
+    )
   } catch (e) {
-    console.log(e)
-    await client.mutate({
-      mutation: SET_ERROR,
-      variables: { message: e.message }
-    })
+    console.error('setupClient', e)
   }
-  ReactDOM.render(
-    <ApolloProvider client={client}>
-      <GlobalStateProvider>
-        <App />
-      </GlobalStateProvider>
-    </ApolloProvider>,
-    document.getElementById('root')
-  )
 })


### PR DESCRIPTION
Hi there!

Whenever I try to reach ens-app over Opera Browser, If Metamask enabled, I'm having this issue;
```js
Uncaught (in promise) TypeError: Cannot read property 'mutate' of undefined
    at index.js:20
    at u (runtime.js:45)
    at Generator._invoke (runtime.js:264)
    at Generator.e.<computed> [as throw] (runtime.js:98)
    at r (asyncToGenerator.js:3)
    at f (asyncToGenerator.js:29)
```
Opera version: 63.0.3368.75

After solving the issue above, if I search an ens name which already owned by someone else, I see this error;
```
Unhandled Rejection (TypeError): Cannot read property 'ethusd' of undefined
```


So, the PR intended to fix them.