### PR TITLE
Downgrade node to 8.11 on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ dist: trusty
 language: node_js
 
 node_js:
-  - '10'
+  - '8.11.4'
 
 cache: yarn
 


### PR DESCRIPTION
`yarn` kept failing when installing sha3 (which I am not sure where the dependency is coming from).
After the google research I bumped into the github issue which suggest to downgrade.

https://github.com/phusion/node-sha3/issues/32#issuecomment-385259045