### PR TITLE
Install the same version of cypress

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ jobs:
       name: 'Test'
       install:
         - yarn
-        - yarn global add cypress
+        - yarn global add cypress@3.5.0
         - cypress install
         - yarn global add ganache-cli@6.1.8
         - yarn global add wait-on


### PR DESCRIPTION
It was complaining that some cypress dependency had an incompatible versions. As a solution, specify the exact cypress version into Travis as same as the one specified at package.json