### PR TITLE
Upgrade node.js to lts/dubnium

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,9 @@
 sudo: required
 
-dist: trusty
-
 language: node_js
 
 node_js:
-  - '8.11.4'
+  - lts/dubnium
 
 cache:
   yarn: true


### PR DESCRIPTION
This is to fix `error stellar-base@2.1.3: The engine "node" is incompatible with this module. Expected version ">=10.16.3"` error