### PR TITLE
use http for .onion content

### DIFF
--- a/src/components/Links/ContentHashLink.js
+++ b/src/components/Links/ContentHashLink.js
@@ -45,7 +45,7 @@ const ContentHashLink = ({ value, contentType }) => {
     externalLink = `https://swarm-gateways.net/bzz://${decoded}`
     url = `bzz://${decoded}`
   } else if (protocolType === 'onion' || protocolType === 'onion3') {
-    externalLink = `https://${decoded}.onion`
+    externalLink = `http://${decoded}.onion`
     url = `onion://${decoded}`
   } else {
     console.warn(`Unsupported protocol ${protocolType}`)


### PR DESCRIPTION
Potentially solves #623 

As mentioned in the comment in the issue, many .onion sites do not have SSL certs, and some even see them as detrimental. I have yet to see a v3 (super long 56 character addresses) address that can be accessed using `https://`, including the [CIA](ciadotgov4sjwlzihbbgxnqg3xiyrg7so2r2o3lt5wz5ypk4sxyjstad.onion)'s, though I cannot confirm if there's something built in to these addresses that doesn't allow it.

As a result of the above, this PR proposes connecting to .onion content using `http://`, not `https://`. Since .onion sites are already end-to-end encrypted, this shouldn't weaken security. (Some sources linked in #623 in the comment.)