### PR TITLE
Fix etherscan link

### DIFF
--- a/src/components/Address/Address.js
+++ b/src/components/Address/Address.js
@@ -246,10 +246,7 @@ export default function Address({
           <SingleNameBlockies address={address} />
           <Title>{address}</Title>
           {etherScanAddr && (
-            <EtherScanLink
-              target="_blank"
-              href={`${etherScanAddr}/address/${address}`}
-            >
+            <EtherScanLink address={address}>
               {t('address.etherscanButton')}
             </EtherScanLink>
           )}

--- a/src/components/Links/EtherScanLink.js
+++ b/src/components/Links/EtherScanLink.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import styled from '@emotion/styled'
+import useNetworkInfo from '../NetworkInformation/useNetworkInfo'
 import { ReactComponent as ExternalLinkIcon } from '../Icons/externalLink.svg'
 
 const EtherScanLinkContainer = styled('a')`
@@ -21,15 +22,20 @@ const EtherScanLinkContainer = styled('a')`
   }
 `
 
-const EtherScanLink = ({ children, address, className }) => (
-  <EtherScanLinkContainer
-    target="_blank"
-    href={`http://etherscan.io/address/${address}`}
-    className={className}
-  >
-    {children}
-    <ExternalLinkIcon />
-  </EtherScanLinkContainer>
-)
+const EtherScanLink = ({ children, address, className }) => {
+  const { network } = useNetworkInfo()
+  const subdomain = network === 'main' ? '' : `${network}.`
+  return (
+    <EtherScanLinkContainer
+      target="_blank"
+      rel="noopener"
+      href={`https://${subdomain}etherscan.io/address/${address}`}
+      className={className}
+    >
+      {children}
+      <ExternalLinkIcon />
+    </EtherScanLinkContainer>
+  )
+}
 
 export default EtherScanLink


### PR DESCRIPTION
Fixes and improvements for Etherscan link of user address.

## Issue number
Resolves #692 .

## Description

Etherscan address was passed wrong in `Address` component, with fix works as intended.

## List of features added/changed

- [x] Testnet url support (rinkeby, ropsten, goerli.etherscan.io)  Relevant url will shown if user uses another network.
- [x] add `rel="noopener"` ([for more](https://web.dev/external-anchors-use-rel-noopener/))
- [x] `https` for prevent redirection

## How Has This Been Tested?

Manual Testing

## Screenshots (if appropriate): - 

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My code implements all the required features.
