### PR TITLE
Shorten hex name on display

### DIFF
--- a/src/components/NetworkInformation/NetworkInformation.js
+++ b/src/components/NetworkInformation/NetworkInformation.js
@@ -10,6 +10,7 @@ import Loader from 'components/Loader'
 import useNetworkInfo from './useNetworkInfo'
 import { useQuery } from 'react-apollo'
 import { GET_REVERSE_RECORD } from '../../graphql/queries'
+import { shortenHexName } from '../../utils/utils'
 
 const NetworkInformationContainer = styled('div')`
   position: relative;
@@ -121,8 +122,9 @@ function NetworkInformation() {
       address
     }
   })
-  const displayName =
-    getReverseRecord && getReverseRecord.name ? getReverseRecord.name : address
+  const displayName = shortenHexName(
+    getReverseRecord?.name ? getReverseRecord.name : address
+  )
 
   if (loading) {
     return (

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -159,3 +159,14 @@ export const emptyAddress = _emptyAddress
 export function isShortName(term) {
   return [...term].length < 3
 }
+
+export function shortenHexName(name) {
+  if (!name) return ''
+  let parts = name.split('.')
+  parts = parts.map(part =>
+    part.match(/\[(.*?)\]/g) //check if part is unknown hex
+      ? part.replace(new RegExp('^(.{0,4}).*(.{4})$', 'im'), '$1...$2')
+      : part
+  )
+  return parts.join('.')
+}


### PR DESCRIPTION
Hey there,
It's an unknown (hex) url shortener.

## Issue number
Resolves #657 

## Description
If users have unknown (hex) url as like me, they will have quite long url on left account information component, like;
`[6f010af653ebe3cb07d297a4ef13366103d392ceffa68dd48232e6e9ff2187bf].eth`
or as subdomain
`[6f010af653ebe3cb07d297a4ef13366103d392ceffa68dd48232e6e9ff2187bf].test.eth`

So whether it's domain or subdomain, the util function will change those links as `[6f0...7bf].test.eth` or `[6f0...7bf].eth`

## List of features added/changed

- [x] Hex shortener util function


## How Has This Been Tested?

Manual Testing

## Screenshots (if appropriate):

<img width="437" alt="image" src="https://user-images.githubusercontent.com/2774845/80824226-4aabe000-8bde-11ea-8148-0b9debf4564b.png">


## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My code implements all the required features.
