### PR TITLE
Changed copy from 7 character min to 3 character min

### DIFF
--- a/public/locales/de.json
+++ b/public/locales/de.json
@@ -263,7 +263,7 @@
     "tooShort": {
       "long": "Names less than 6 characters have been reserved for when the permanent registrar has been released.",
       "short1": "Name is too short.",
-      "short2": "Names must be at least 7 characters long"
+      "short2": "Names must be at least 3 characters long"
     },
     "unsupported": {
       "long": "We do not support every single domain. Support for future domains are planned in the future",

--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -263,7 +263,7 @@
     "tooShort": {
       "long": "Names less than 6 characters have been reserved for when the permanent registrar has been released.",
       "short1": "Name is too short.",
-      "short2": "Names must be at least 7 characters long"
+      "short2": "Names must be at least 3 characters long"
     },
     "unsupported": {
       "long": "We do not support every single domain. Support for future domains are planned in the future",

--- a/public/locales/ja.json
+++ b/public/locales/ja.json
@@ -261,7 +261,7 @@
     "tooShort": {
       "long": "Names less than 6 characters have been reserved for when the permanent registrar has been released.",
       "short1": "Name is too short.",
-      "short2": "Names must be at least 7 characters long"
+      "short2": "Names must be at least 3 characters long"
     },
     "unsupported": {
       "long": "We do not support every single domain. Support for future domains are planned in the future",


### PR DESCRIPTION
## Issue number

<!--- If there is an associated github issues, please specify here -->

## Description

* Modified short domain error copy from "must be 7 characters" to "must be 3 characters" since https://medium.com/the-ethereum-name-service/the-most-popular-eth-names-in-the-ens-short-name-auction-final-5d3466dd8837 "Next Steps" paragraph (https://twitter.com/ensdomains/status/1192169148815728640)

## List of features added/changed

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-
-
-

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My code implements all the required features.
