### PR TITLE
Typo correction

### DIFF
--- a/public/locales/de.json
+++ b/public/locales/de.json
@@ -196,7 +196,7 @@
     },
     "notify": "Benachrichtige mich",
     "premium": {
-      "dateDescription": "Time shown in local time zone",
+      "dateDescription": "Date and time shown in local time zone",
       "invalid": "Any number over 2k is invalid",
       "title": "Premium"
     },

--- a/public/locales/de.json
+++ b/public/locales/de.json
@@ -196,7 +196,7 @@
     },
     "notify": "Benachrichtige mich",
     "premium": {
-      "dateDescription": "Date of peremium price in local time zone",
+      "dateDescription": "Time shown in local time zone",
       "invalid": "Any number over 2k is invalid",
       "title": "Premium"
     },

--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -196,7 +196,7 @@
     },
     "notify": "Notify me",
     "premium": {
-      "dateDescription": "Time shown in local time zone",
+      "dateDescription": "Date and time shown in local time zone",
       "invalid": "Any number over 2k is invalid",
       "title": "Premium"
     },

--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -196,7 +196,7 @@
     },
     "notify": "Notify me",
     "premium": {
-      "dateDescription": "Date of peremium price in local time zone",
+      "dateDescription": "Time shown in local time zone",
       "invalid": "Any number over 2k is invalid",
       "title": "Premium"
     },

--- a/public/locales/ja.json
+++ b/public/locales/ja.json
@@ -194,7 +194,7 @@
     },
     "notify": "通知する",
     "premium": {
-      "dateDescription": "Time shown in local time zone",
+      "dateDescription": "Date and time shown in local time zone",
       "invalid": "Any number over 2k is invalid",
       "title": "Premium"
     },

--- a/public/locales/ja.json
+++ b/public/locales/ja.json
@@ -194,7 +194,7 @@
     },
     "notify": "通知する",
     "premium": {
-      "dateDescription": "Date of peremium price in local time zone",
+      "dateDescription": "Time shown in local time zone",
       "invalid": "Any number over 2k is invalid",
       "title": "Premium"
     },


### PR DESCRIPTION
In the Manager copy changed, "premium" had a typo, and the word "date" didn't really make sense by itself. I've adjusted it to make more sense.