### PR TITLE
Update LanguageSwitcher.js

### DIFF
--- a/src/components/LanguageSwitcher/LanguageSwitcher.js
+++ b/src/components/LanguageSwitcher/LanguageSwitcher.js
@@ -36,7 +36,7 @@ const LANGUAGES = [
   },
   {
     value: 'pl',
-    label: 'Polskie (PL)'
+    label: 'Polski (PL)'
   },
   {
     value: 'ru',


### PR DESCRIPTION
Polish translator emailed me saying we had "Polish" in Polish spelled wrong, this fixes it