### PR TITLE
Display reverse records

### DIFF
--- a/src/components/Address/Address.js
+++ b/src/components/Address/Address.js
@@ -97,9 +97,7 @@ const SelectAll = styled('div')`
 `
 
 function filterOutReverse(domains) {
-  return domains.filter(
-    domain => domain.parent && domain.parent.name !== 'addr.reverse'
-  )
+  return domains.filter(domain => domain.parent)
 }
 
 function normaliseAddress(address) {

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -107,7 +107,10 @@ export const parseSearchTerm = async term => {
     return 'invalid'
   }
   const address = await ens.getOwner(tld)
-  return _parseSearchTerm(term, parseInt(address, 16) !== 0)
+  return _parseSearchTerm(
+    term,
+    parseInt(address, 16) !== 0 || tld === 'reverse'
+  )
 }
 
 export function humaniseName(name) {


### PR DESCRIPTION

## Issue number

https://github.com/ensdomains/ens-app/issues/931

## Description

<!--- Describe your changes in detail -->

## List of features added/changed

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-  shows `addr.reverse` as part of the the controller the address own.
- can go to `name/***.addr.reverse`
- `name/addre.reverse/subdomains` shows the list of reverse records


## Screenshots (if appropriate):

<img width="1142" alt="Screenshot 2020-10-19 at 21 03 29" src="https://user-images.githubusercontent.com/2630/96505892-a92d4f00-124e-11eb-8b78-6d103afc9b66.png">
<img width="1137" alt="Screenshot 2020-10-19 at 21 03 13" src="https://user-images.githubusercontent.com/2630/96505901-aa5e7c00-124e-11eb-8c53-fdc28542e7d7.png">
<img width="1113" alt="Screenshot 2020-10-19 at 21 05 55" src="https://user-images.githubusercontent.com/2630/96506074-eabdfa00-124e-11eb-9da6-95cb23ec7b2d.png">
