### PR TITLE
Fix language dropdown display bug

### DIFF
--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -22,6 +22,7 @@ const Header = styled('header')`
   left: 0;
   top: 0;
   width: 100%;
+  z-index: 2;
   box-shadow: 0 4px 8px 0 rgba(230, 240, 247, 0.8);
   height: 50px;
   ${mq.medium`

--- a/src/components/LanguageSwitcher/LanguageSwitcher.js
+++ b/src/components/LanguageSwitcher/LanguageSwitcher.js
@@ -83,7 +83,7 @@ const Dropdown = styled(motion.div)`
   border-radius: 8px;
   box-shadow: -4px 18px 70px 0 rgba(108, 143, 167, 0.32);
   width: 230px;
-  z-index: 1;
+  z-index: 2;
   li {
     color: #adbbcd;
     padding: 20px 30px;


### PR DESCRIPTION
Language overlay seems broken since I integrated wallet modal 

<img width="1729" alt="Screenshot 2020-12-08 at 10 37 50" src="https://user-images.githubusercontent.com/2630/101473251-7dbb0c80-3941-11eb-9213-3938adb744b5.png">
<img width="1094" alt="Screenshot 2020-12-08 at 10 37 28" src="https://user-images.githubusercontent.com/2630/101473261-7f84d000-3941-11eb-84a0-7f0246d5759f.png">


<img width="1748" alt="Screenshot 2020-12-08 at 10 37 59" src="https://user-images.githubusercontent.com/2630/101473245-7c89df80-3941-11eb-80bc-6430f9151bf5.png">

This PR is to fix the issue