### PR TITLE
Override registrar address only if tldowner is empty

### DIFF
--- a/public/locales/cn.json
+++ b/public/locales/cn.json
@@ -35,6 +35,7 @@
     "about": "关于",
     "addresses": "地址",
     "cancel": "取消",
+    "cannotclaimDns": "You cannot claim names under .{{ name }} on this site.",
     "claim": "申请",
     "connect": "连接",
     "disconnect": "断开连接",

--- a/public/locales/de.json
+++ b/public/locales/de.json
@@ -37,6 +37,7 @@
     "about": "Über",
     "addresses": "Adressen",
     "cancel": "Abbrechen",
+    "cannotclaimDns": "You cannot claim names under .{{ name }} on this site.",
     "claim": "Nehmen",
     "connect": "Connect",
     "disconnect": "Disconnect",

--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -37,6 +37,7 @@
     "about": "About",
     "addresses": "Addresses",
     "cancel": "Cancel",
+    "cannotclaimDns": "You cannot claim names under .{{ name }} on this site.",
     "claim": "Claim",
     "connect": "Connect",
     "disconnect": "Disconnect",

--- a/public/locales/es.json
+++ b/public/locales/es.json
@@ -37,6 +37,7 @@
     "about": "Acerca",
     "addresses": "Addresses",
     "cancel": "Cancelar",
+    "cannotclaimDns": "You cannot claim names under .{{ name }} on this site.",
     "claim": "Reclamar",
     "connect": "Connect",
     "disconnect": "Disconnect",

--- a/public/locales/fr.json
+++ b/public/locales/fr.json
@@ -37,6 +37,7 @@
     "about": "À propos",
     "addresses": "Addresses",
     "cancel": "Annuler",
+    "cannotclaimDns": "You cannot claim names under .{{ name }} on this site.",
     "claim": "Revendiquer",
     "connect": "Connect",
     "disconnect": "Disconnect",

--- a/public/locales/ja.json
+++ b/public/locales/ja.json
@@ -36,6 +36,7 @@
     "about": "ENSとは",
     "addresses": "Addresses",
     "cancel": "キャンセル",
+    "cannotclaimDns": "You cannot claim names under .{{ name }} on this site.",
     "claim": "請求",
     "connect": "Connect",
     "disconnect": "Disconnect",

--- a/public/locales/ko.json
+++ b/public/locales/ko.json
@@ -36,6 +36,7 @@
     "about": "ENS란?",
     "addresses": "Addresses",
     "cancel": "취소",
+    "cannotclaimDns": "You cannot claim names under .{{ name }} on this site.",
     "claim": "요청",
     "connect": "Connect",
     "disconnect": "Disconnect",

--- a/public/locales/pl.json
+++ b/public/locales/pl.json
@@ -38,6 +38,7 @@
     "about": "O Nas",
     "addresses": "Addresses",
     "cancel": "Anuluj",
+    "cannotclaimDns": "You cannot claim names under .{{ name }} on this site.",
     "claim": "Odbierz",
     "connect": "Connect",
     "disconnect": "Disconnect",

--- a/public/locales/ru.json
+++ b/public/locales/ru.json
@@ -38,6 +38,7 @@
     "about": "О",
     "addresses": "Addresses",
     "cancel": "Отменить",
+    "cannotclaimDns": "You cannot claim names under .{{ name }} on this site.",
     "claim": "Заявить",
     "connect": "Connect",
     "disconnect": "Disconnect",

--- a/public/locales/vi.json
+++ b/public/locales/vi.json
@@ -36,6 +36,7 @@
     "about": "Giới thiệu",
     "addresses": "Addresses",
     "cancel": "Hủy bỏ",
+    "cannotclaimDns": "You cannot claim names under .{{ name }} on this site.",
     "claim": "Sở hữu",
     "connect": "Connect",
     "disconnect": "Disconnect",

--- a/src/api/manager/resolvers.js
+++ b/src/api/manager/resolvers.js
@@ -112,10 +112,9 @@ async function getDNSEntryDetails(name) {
   let tld = nameArray[1]
   let owner
   let tldowner
-  if (networkId === 3) {
+  tldowner = (await ens.getOwner(tld)).toLocaleLowerCase()
+  if (parseInt(tldowner) === 0 && networkId === 3) {
     tldowner = ROPSTEN_DNSREGISTRAR_ADDRESS
-  } else {
-    tldowner = (await ens.getOwner(tld)).toLocaleLowerCase()
   }
 
   try {

--- a/src/components/SingleName/NameDetails.js
+++ b/src/components/SingleName/NameDetails.js
@@ -256,7 +256,7 @@ function DetailsContainer({
       {showUnclaimableWarning && (
         <GracePeriodWarningContainer>
           <DetailsItem>
-            You cannot claim names under .{domainParent} on this site.
+            {t('c.cannotclaimDns', { name: domainParent })}
             <LinkToLearnMore
               href="https://docs.ens.domains/dns-registrar-guide"
               target="_blank"

--- a/src/components/SingleName/NameDetails.js
+++ b/src/components/SingleName/NameDetails.js
@@ -220,7 +220,11 @@ function DetailsContainer({
 
   const is2ld = domain.name.split('.').length === 2
   const showUnclaimableWarning =
-    domain.parent !== 'eth' && is2ld && parseInt(domain.owner) === 0
+    is2ld &&
+    parseInt(domain.owner) === 0 &&
+    domain.parent !== 'eth' &&
+    !domain.isDNSRegistrar
+
   return (
     <Details data-testid="name-details">
       {isOwner && <SetupName initialState={showExplainer} />}

--- a/src/components/SingleName/NameDetails.js
+++ b/src/components/SingleName/NameDetails.js
@@ -218,6 +218,9 @@ function DetailsContainer({
   const domainParent =
     domain.name === '[root]' ? null : domain.parent ? domain.parent : '[root]'
 
+  const is2ld = domain.name.split('.').length === 2
+  const showUnclaimableWarning =
+    domain.parent !== 'eth' && is2ld && parseInt(domain.owner) === 0
   return (
     <Details data-testid="name-details">
       {isOwner && <SetupName initialState={showExplainer} />}
@@ -245,6 +248,22 @@ function DetailsContainer({
         </DetailsItem>
       ) : (
         ''
+      )}
+      {showUnclaimableWarning && (
+        <GracePeriodWarningContainer>
+          <DetailsItem>
+            You cannot claim names under .{domainParent} on this site.
+            <LinkToLearnMore
+              href="https://docs.ens.domains/dns-registrar-guide"
+              target="_blank"
+            >
+              {t('c.learnmore')}{' '}
+              <EtherScanLinkContainer>
+                <ExternalLinkIcon />
+              </EtherScanLinkContainer>
+            </LinkToLearnMore>
+          </DetailsItem>
+        </GracePeriodWarningContainer>
       )}
       <OwnerFields outOfSync={outOfSync}>
         {domain.parent === 'eth' && domain.isNewRegistrar ? (

--- a/src/routes/Faq.js
+++ b/src/routes/Faq.js
@@ -124,7 +124,7 @@ function Faq() {
         can use the DNS record as the proof to claim the equivalent ENS names.
         <br />
         Please refer to our{' '}
-        <a href="https://docs.ens.domains/dns-registrar-guide">guiide</a> for
+        <a href="https://docs.ens.domains/dns-registrar-guide">guide</a> for
         more detail.
       </Section>
 


### PR DESCRIPTION
Resolve https://github.com/ensdomains/ens-app/issues/1104

It shows the following warning if 2ld is empty and owner is not dnsregistrar

<img width="733" alt="Screenshot 2021-03-29 at 16 43 40" src="https://user-images.githubusercontent.com/2630/112864649-ec1e0900-90af-11eb-936c-9cbd3e6674d3.png">
