### PR TITLE
do not throw when domain has no name

### DIFF
--- a/src/api/labels.js
+++ b/src/api/labels.js
@@ -45,7 +45,7 @@ export function checkLabel(hash) {
 }
 
 export function checkIsDecrypted(string) {
-  return !string.includes('[')
+  return !string?.includes('[')
 }
 
 export function decryptName(name) {

--- a/src/components/AddReverseRecord.js
+++ b/src/components/AddReverseRecord.js
@@ -134,8 +134,8 @@ function AddReverseRecord({ account, currentAddress }) {
     options = _.uniq(
       resolvers
         .map(r => {
-          if (checkIsDecrypted(r.domain.name)) {
-            return r.domain.name
+          if (checkIsDecrypted(r?.domain?.name)) {
+            return r?.domain?.name
           } else {
             let decrypted = decryptName(r.domain.name)
             // Ignore if label is not found


### PR DESCRIPTION
http://localhost:3000/address/0xcf88FA6eE6D111b04bE9b06ef6fAD6bD6691B88c is throwing error because some domain does not have name on subgraph