### PR TITLE
handleParse() trims all whitespace in Search component

### DIFF
--- a/src/components/SearchName/Search.js
+++ b/src/components/SearchName/Search.js
@@ -77,7 +77,12 @@ function Search({ history, className, style }) {
   let input
 
   const handleParse = e => {
-    setInputValue(e.target.value)
+    setInputValue(
+      e.target.value
+        .split('.')
+        .map(term => term.trim())
+        .join('.')
+    )
   }
   const hasSearch = inputValue && inputValue.length > 0
   return (
@@ -92,7 +97,8 @@ function Search({ history, className, style }) {
         const type = await parseSearchTerm(inputValue)
         let searchTerm
         if (input && input.value) {
-          searchTerm = input.value.toLowerCase()
+          // inputValue doesn't have potential whitespace
+          searchTerm = inputValue.toLowerCase()
         }
         if (!searchTerm || searchTerm.length < 1) {
           return


### PR DESCRIPTION
## Issue number

https://github.com/ensdomains/ens-app/issues/1152

## Description

Whitespace wasn't being trimmed as mentioned in the issue, so I split the search by into an array, then map() to trim each array item, and lastly join() back into a string

## List of features added/changed

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- Validates user input

## How Has This Been Tested?

I searched some of the following terms to see if the 'malformed error' showed up:
" foo.eth", "foo .eth", "foo. bar.eth "

## Screenshots (if appropriate):
Gif of new search
![Peek 2021-05-31 16-42](https://user-images.githubusercontent.com/61043071/120166603-54fc3b80-c22f-11eb-867f-9ef715c5adc2.gif)


## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ x] My code follows the code style of this project.
- [ x] My code implements all the required features.
