### PR TITLE
Exclude dropdown toggler from click outside effect

### DIFF
--- a/src/components/Calendar/Calendar.js
+++ b/src/components/Calendar/Calendar.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { forwardRef } from 'react'
 import AddToCalendarHOC from 'react-add-to-calendar-hoc'
 import Dropdown from './Dropdown'
 import DefaultButton from '../Forms/Button'
@@ -27,13 +27,13 @@ const Button = styled(DefaultButton)`
   }
 `
 
-const CalendarButton = props => (
-  <Button type="hollow-primary" {...props}>
+const CalendarButton = forwardRef((props, ref) => (
+  <Button type="hollow-primary" ref={ref} {...props}>
     <img src={calendar} alt="calendar icon" />
     &nbsp;
     {props.children}
   </Button>
-)
+))
 
 function CalendarInvite({ noMargin, dropDownLinks = [], event, invalid }) {
   const { t } = useTranslation()

--- a/src/components/ExpiryNotification/ExpiryNotifyDropdown.js
+++ b/src/components/ExpiryNotification/ExpiryNotifyDropdown.js
@@ -14,11 +14,12 @@ const ExpiryNotifyDropdownContainer = styled('div')`
 
 export default function ExpiryNotifyDropdown({ address }) {
   const dropdownRef = createRef()
+  const togglerRef = createRef()
   const [showDropdown, setShowDropdown] = useState(false)
   const [showModal, setShowModal] = useState(false)
   const { t } = useTranslation()
 
-  useOnClickOutside(dropdownRef, () => setShowDropdown(false))
+  useOnClickOutside([dropdownRef, togglerRef], () => setShowDropdown(false))
 
   const handleDropdownClick = () => {
     setShowDropdown(value => !value)
@@ -35,7 +36,7 @@ export default function ExpiryNotifyDropdown({ address }) {
 
   return (
     <ExpiryNotifyDropdownContainer>
-      <CalendarButton onClick={handleDropdownClick}>
+      <CalendarButton ref={togglerRef} onClick={handleDropdownClick}>
         {t('expiryNotification.reminder')}
       </CalendarButton>
       {showDropdown && (

--- a/src/components/LanguageSwitcher/LanguageSwitcher.js
+++ b/src/components/LanguageSwitcher/LanguageSwitcher.js
@@ -134,13 +134,14 @@ function getLanguageFromLocalStorage() {
 
 export default function LanguageSwitcher() {
   const dropdownRef = createRef()
+  const togglerRef = createRef()
   const [languageSelected, setLanguageSelected] = useState(
     getLang(getLanguageFromLocalStorage()) ?? getLang('en')
   )
   const [showDropdown, setShowDropdown] = useState(false)
   const { i18n } = useTranslation()
 
-  useOnClickOutside(dropdownRef, () => setShowDropdown(false))
+  useOnClickOutside([dropdownRef, togglerRef], () => setShowDropdown(false))
 
   function changeLanguage(language) {
     setLanguageSelected(language)
@@ -151,7 +152,10 @@ export default function LanguageSwitcher() {
 
   return (
     <LanguageSwitcherContainer>
-      <ActiveLanguage onClick={() => setShowDropdown(show => !show)}>
+      <ActiveLanguage
+        ref={togglerRef}
+        onClick={() => setShowDropdown(show => !show)}
+      >
         <span>{languageSelected.value}</span>
         <RotatingSmallCaret
           start="top"

--- a/src/components/hooks.js
+++ b/src/components/hooks.js
@@ -227,11 +227,14 @@ export function useBlock() {
   }
 }
 
-export function useOnClickOutside(ref, handler) {
+export function useOnClickOutside(refs = [], handler) {
   useEffect(() => {
     const listener = event => {
-      if (!ref.current || ref.current.contains(event.target)) {
-        return
+      // Do nothing if any of given refs or descendants are clicked
+      for (let i = 0; i < refs.length; i++) {
+        if (!refs[i].current || refs[i].current.contains(event.target)) {
+          return
+        }
       }
       handler(event)
     }
@@ -243,5 +246,5 @@ export function useOnClickOutside(ref, handler) {
       document.removeEventListener('mousedown', listener)
       document.removeEventListener('touchstart', listener)
     }
-  }, [ref, handler])
+  }, [refs, handler])
 }


### PR DESCRIPTION
Improvement on top of #1190 for #1161. 

This PR aims to exclude toggler of dropdown items from clicking outside effect. Without this PR, if user opens a dropdown and click to the toggler for closing purpose, it will close the dropdown just because user clicked outside of the dropdown, but later it will be reopened because in fact user clicked on toggler (button/link/icon etc). 