### PR TITLE
Update README.md to include lowest required Node.js version

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ ENS Application
 
 ### Manual
 
+Expects Node.js version >=14.17.0
+
 ```shell
 $> git clone https://github.com/ensdomains/ens-app.git
 $> cd ens-app


### PR DESCRIPTION
Adds expected Node.js version

## Description

Installing using `yarn install` will fail if Node.js version is below `v14.17.0`

## Checklist:

- [x] My code follows the code style of this project.
- [x] My code implements all the required features.
