### PR TITLE
Add @davatar/react package for more robust avatar image lookup

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "@0xproject/utils": "^0.7.3",
     "@buidlhub/buidlhub-ens-notifications": "^1.0.3",
-    "@davatar/react": "^1.0.0",
+    "@davatar/react": "^1.3.3",
     "@emotion/core": "^10.0.9",
     "@emotion/styled": "^10.0.9",
     "@ensdomains/address-encoder": "^0.2.8",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "dependencies": {
     "@0xproject/utils": "^0.7.3",
     "@buidlhub/buidlhub-ens-notifications": "^1.0.3",
+    "@davatar/react": "^1.0.0",
     "@emotion/core": "^10.0.9",
     "@emotion/styled": "^10.0.9",
     "@ensdomains/address-encoder": "^0.2.8",

--- a/src/components/NetworkInformation/NetworkInformation.js
+++ b/src/components/NetworkInformation/NetworkInformation.js
@@ -1,6 +1,7 @@
 import React, { useState, useContext } from 'react'
 import styled from '@emotion/styled/macro'
 import { useTranslation } from 'react-i18next'
+import { Image } from '@davatar/react'
 
 import mq from 'mediaQuery'
 import GlobalState from '../../globalState'
@@ -37,8 +38,10 @@ const Blockies = styled(UnstyledBlockies)`
   `}
 `
 
-const Avatar = styled('img')`
+const Avatar = styled('div')`
   width: 48px;
+  height: 48px;
+  border-radius: 48px;
   position: absolute;
   left: 10px;
   top: 10px;
@@ -179,9 +182,12 @@ function NetworkInformation() {
           {!reverseRecordLoading &&
           getReverseRecord &&
           getReverseRecord.avatar ? (
-            <Avatar
-              src={imageUrl(getReverseRecord.avatar, displayName, network)}
-            />
+            <Avatar>
+              <Image
+                size={48}
+                uri={imageUrl(getReverseRecord.avatar, displayName, network)}
+              />
+            </Avatar>
           ) : (
             <Blockies address={accounts[0]} imageSize={47} />
           )}

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -287,6 +287,6 @@ export function imageUrl(url, name, network) {
   if (name && network === 'rinkeby' && url.match(/^eip/)) {
     return `https://ens-metadata-service.appspot.com/avatar/${name}`
   } else {
-    return prependUrl(url)
+    return url
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1403,6 +1403,15 @@
     debug "^3.1.0"
     lodash.once "^4.1.1"
 
+"@davatar/react@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@davatar/react/-/react-1.0.0.tgz#3382b655bad05c8289d80494f4dd4666b904c473"
+  integrity sha512-qDNedpiII9poFOrHEV0guzRdqOyrpP9H18dm0yMo+piGvosJ0ZxW6TTIUXcLnp7orAWFXxkOCJaYVCVoLVw9Zg==
+  dependencies:
+    color "^3.2.1"
+    ethers "^5.4.6"
+    mersenne-twister "^1.1.0"
+
 "@emotion/cache@^10.0.27", "@emotion/cache@^10.0.9":
   version "10.0.29"
   resolved "https://registry.yarnpkg.com/@emotion/cache/-/cache-10.0.29.tgz#87e7e64f412c060102d589fe7c6dc042e6f9d1e0"
@@ -6981,7 +6990,7 @@ color-string@^1.6.0:
     color-name "^1.0.0"
     simple-swizzle "^0.2.2"
 
-color@^3.0.0:
+color@^3.0.0, color@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/color/-/color-3.2.1.tgz#3544dc198caf4490c3ecc9a790b54fe9ff45e164"
   integrity sha512-aBl7dZI9ENN6fUGC7mWpMTPNHmWUSNan9tuWN6ahh5ZLNk9baLJOnSMlrQkHcrfFgz2/RigjUVAjdx36VcemKA==
@@ -9771,7 +9780,7 @@ ethers@^4.0.0-beta.1, ethers@^4.0.32:
     uuid "2.0.1"
     xmlhttprequest "1.8.0"
 
-ethers@^5.0.0, ethers@^5.0.1, ethers@^5.0.17, ethers@^5.0.2, ethers@^5.0.30:
+ethers@^5.0.0, ethers@^5.0.1, ethers@^5.0.17, ethers@^5.0.2, ethers@^5.0.30, ethers@^5.4.6:
   version "5.4.6"
   resolved "https://registry.yarnpkg.com/ethers/-/ethers-5.4.6.tgz#fe0a023956b5502c947f58e82fbcf9a73e5e75b6"
   integrity sha512-F7LXARyB/Px3AQC6/QKedWZ8eqCkgOLORqL4B/F0Mag/K+qJSFGqsR36EaOZ6fKg3ZonI+pdbhb4A8Knt/43jQ==
@@ -14720,6 +14729,11 @@ merkle-patricia-tree@^4.2.0:
     readable-stream "^3.6.0"
     rlp "^2.2.4"
     semaphore-async-await "^1.5.1"
+
+mersenne-twister@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/mersenne-twister/-/mersenne-twister-1.1.0.tgz#f916618ee43d7179efcf641bec4531eb9670978a"
+  integrity sha1-+RZhjuQ9cXnvz2Qb7EUx65Zwl4o=
 
 methods@~1.1.2:
   version "1.1.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1403,10 +1403,10 @@
     debug "^3.1.0"
     lodash.once "^4.1.1"
 
-"@davatar/react@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@davatar/react/-/react-1.0.0.tgz#3382b655bad05c8289d80494f4dd4666b904c473"
-  integrity sha512-qDNedpiII9poFOrHEV0guzRdqOyrpP9H18dm0yMo+piGvosJ0ZxW6TTIUXcLnp7orAWFXxkOCJaYVCVoLVw9Zg==
+"@davatar/react@^1.3.3":
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/@davatar/react/-/react-1.3.3.tgz#d8821024438690993b4cf6541f448554ff7ab265"
+  integrity sha512-M0KZ53ZM8guObt/f9SaCgCvAPnmPGuu6h8wJiFPGOumw2Gt+wSnymvCJPZBwWcPyTjvBGloaBRalf1F+R8fIHg==
   dependencies:
     color "^3.2.1"
     ethers "^5.4.6"


### PR DESCRIPTION
## Description

This PR adds more robust avatar image lookup support to the ENS app's `avatar` text record lookup for the logged in user's avatar, using the [@davatar/react](https://github.com/TBDAO/davatar-helpers/tree/master/packages/react) package, which seeks to fulfill the spec outlined in [avatars.md](https://gist.github.com/Arachnid/9db60bd75277969ee1689c8742b75182).

It supports the full spec as outlined in the ENS avatar spec document. Our goal is to push forward usage of decentralized avatars using ENS, and this PR works toward making sure as people do so, they see their avatars correctly in the main ENS app.

We also make the avatars round, because everyone wants their circle avatars these days 😄 

## List of features added/changed

- Add `@davatar/react` dependency (small, 7kb)
- Replace the bare `img` tag for rendering avatars with the `<Image />` component from `@davatar/react`, which supports several decentralized URI protocols
- Add a border-radius to circularize avatars
- Remove helper that changes non https urls into https urls, because it interferes with other protocol types.

## How Has This Been Tested?

Connected my wallet in the local dev environment and checked that it rendered my avatar correctly.

## Screenshots (if appropriate):
<img width="433" alt="Screen Shot 2021-09-10 at 10 53 29 AM" src="https://user-images.githubusercontent.com/198739/132894265-9717f254-a5ac-457f-b5aa-eaf5cd14d148.png">

## Checklist:

- [x] My code follows the code style of this project.
- [x] My code implements all the required features.
