### PR TITLE
make DNS text record instructions more explicit

### DIFF
--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -88,7 +88,7 @@
     "steps": {
       "addtext": {
         "text": "Click 'learn more' to read about the process.",
-        "title": "Set up a text record in your domain registrar then click refresh. The text record should contain your Ethereum address in the form:"
+        "title": "Set up a text record in your domain registrar then click refresh. The text record should be called '_ens' and should contain your Ethereum address in the form:"
       },
       "enable": {
         "text": "Click 'learn more' to read about the process.",


### PR DESCRIPTION
## Description

Currently, the app itself doesn't reference the actual name of the expected TXT record for DNSSEC-based claiming. The only place this is specified is in the "Learn More" article.

We should have the correct TXT key clearly placed in the UI to avoid confusion.

If we do it like this, I need help with the other localizations.

## List of features added/changed

- Add language about the `_ens` key to the UI

## How Has This Been Tested?

It's a text change.

## Screenshots (if appropriate):

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My code implements all the required features.
