### PR TITLE
Use @apollo/client/react/component on mutation

### DIFF
--- a/src/components/SingleName/DNSNameRegister/CTA.js
+++ b/src/components/SingleName/DNSNameRegister/CTA.js
@@ -1,7 +1,7 @@
 import React, { useState } from 'react'
 import styled from '@emotion/styled/macro'
 import { useTranslation } from 'react-i18next'
-import { Mutation } from 'react-apollo'
+import { Mutation } from '@apollo/client/react/components'
 import { SUBMIT_PROOF } from '../../../graphql/mutations'
 
 import PendingTx from '../../PendingTx'


### PR DESCRIPTION
Initially, it was throwing `uncaught invariant violation` error when registering `black.host` and `goose.glass`