### PR TITLE
Set 0 price if gas price is not available

### DIFF
--- a/src/components/hooks.js
+++ b/src/components/hooks.js
@@ -208,16 +208,10 @@ export function useGasPrice(enabled = true) {
             fast: baseFeeWei * 1.5 + 2 * Math.pow(10, 9)
           }
           setPrice(price)
-          setLoading(false)
         } else {
-          const gasApi = 'https://www.gasnow.org/api/v3/gas/price'
-          const result = await fetch(gasApi)
-          if (!result.ok)
-            throw `Failed to get gas estimate: ${result.statusText}`
-          const data = await result.json()
-          setPrice(data?.data)
-          setLoading(false)
+          setPrice({ slow: 0, fast: 0 })
         }
+        setLoading(false)
       }
       run()
     } catch (e) {


### PR DESCRIPTION
The latest stable ganache doesn't support EIP1559 yet so it won't be able to get the baseFee. Gasnow was used as a fallback but given the service was terminated and the alternatives (eg: ethgasstation) doesn't return accurate data either, I will set fallback gasprice to 0 which should only happen when hitting ganache.