### PR TITLE
Switch to local time (#1168)

### DIFF
--- a/src/components/SingleName/DetailsItemEditable.js
+++ b/src/components/SingleName/DetailsItemEditable.js
@@ -491,6 +491,7 @@ const Editable = ({
                     registrant={domain.registrant}
                     startDatetime={moment(value)
                       .utc()
+                      .local()
                       .subtract(30, 'days')}
                   />
                 </>

--- a/src/components/SingleName/NameRegister/CTA.js
+++ b/src/components/SingleName/NameRegister/CTA.js
@@ -202,6 +202,7 @@ function getCTA({
           name={`${label}.eth`}
           startDatetime={moment()
             .utc()
+            .local()
             .add(duration, 'seconds')
             .subtract(30, 'days')}
         />

--- a/src/components/SingleName/NameRegister/Premium.js
+++ b/src/components/SingleName/NameRegister/Premium.js
@@ -117,7 +117,7 @@ function Premium({
             margin-right: 20px;
           `}
           name={name}
-          startDatetime={targetDate.utc()}
+          startDatetime={targetDate.utc().local()}
           invalid={invalid}
         />
       </CalendarContainer>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue number

<!--- If there is an associated github issues, please specify here -->
#1168 

## Description

<!--- Describe your changes in detail -->
When creating a google reminder, the startDatetime passed as a query param to Google calendar is in UTC time (uses moment.utc()) instead of local time.
![image](https://user-images.githubusercontent.com/53792888/140654115-2beb6178-6a45-43c7-af6c-dc6e80ac88ff.png)

This results in a startDatetime with a utc offset of +0:00:
![image](https://user-images.githubusercontent.com/53792888/140654145-e08aa36e-4ef9-4937-a960-7add3ac84a7e.png)

When switching from UTC to local time using moment.local() method, this results in a startDatetime with a UTC offset that is the same as the local computer:
![image](https://user-images.githubusercontent.com/53792888/140654156-e55cffc0-f4e1-4ad3-859a-84ba4c5aa9b0.png)


## List of features added/changed

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- startDateTime prop passed to AddToCalendar component in name page

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
When running chromium with different TZ environment variable / timezones, it displays a startDateTime with the timezone corresponding UTC offset instead of a UTC offset of +0:00.
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My code implements all the required features.
