### PR TITLE
Fix UI pending transaction

### DIFF
--- a/src/components/AddReverseRecord.js
+++ b/src/components/AddReverseRecord.js
@@ -210,7 +210,16 @@ function AddReverseRecord({ account, currentAddress }) {
   function ReverseRecordEditor() {
     return (
       <>
-        <Message onClick={editing ? stopEditing : startEditing}>
+        <Message
+          onClick={e =>
+            editing
+              ? stopEditing()
+              : pending
+              ? e.preventDefault()
+              : startEditing()
+          }
+          pending={pending}
+        >
           {hasValidReverseRecord(getReverseRecord) ? (
             <MessageContent data-testid="editable-reverse-record-set">
               <Check />

--- a/src/components/AddReverseRecord.js
+++ b/src/components/AddReverseRecord.js
@@ -63,7 +63,7 @@ const Message = styled('div')`
   justify-content: space-between;
 
   &:hover {
-    cursor: pointer;
+    cursor: ${p => (p.pending ? 'default' : 'pointer')};
   }
 `
 

--- a/src/components/AddReverseRecord.js
+++ b/src/components/AddReverseRecord.js
@@ -140,7 +140,9 @@ function AddReverseRecord({ account, currentAddress }) {
 
   const [setName] = useMutation(SET_NAME, {
     onCompleted: data => {
-      startPending(Object.values(data)[0])
+      if (Object.values(data)[0]) {
+        startPending(Object.values(data)[0])
+      }
     }
   })
 

--- a/src/components/DomainItem/ChildDomainItem.js
+++ b/src/components/DomainItem/ChildDomainItem.js
@@ -98,85 +98,87 @@ export default function ChildDomainItem({
   })
 
   return (
-    <DomainLink
-      showBlockies={showBlockies}
-      data-testid={`${name}`}
-      warning={isMigrated === false ? true : false}
-      key={name}
-      to={`/name/${name}`}
-    >
-      {showBlockies && smallBP && (
-        <SingleNameBlockies imageSize={24} address={owner} />
-      )}
-      <h3>{label}</h3>
-      {canDeleteSubdomain ? (
-        pending && !confirmed ? (
-          <PendingTx
-            txHash={txHash}
-            onConfirmed={() => {
-              setConfirmed()
-            }}
-          />
-        ) : (
-          <Bin
-            data-testid={'delete-name'}
-            onClick={e => {
-              e.preventDefault()
-              mutate()
-            }}
-          />
-        )
-      ) : (
-        <>
-          <ExpiryDate name={name} expiryDate={expiryDate} />
-          <AddFavourite
-            domain={{ name }}
-            isSubDomain={false}
-            isFavourite={isFavourite}
-          />
-        </>
-      )}
-
-      {!isDecrypted && (
-        <Tooltip
-          text="<p>This name is only partially decoded. If you know the name, you can search for it in the search bar to decrypt it and renew</p>"
-          position="top"
-          border={true}
-          offset={{ left: 0, top: 10 }}
-        >
-          {({ tooltipElement, showTooltip, hideTooltip }) => {
-            return (
-              <div style={{ position: 'relative' }}>
-                <QuestionMark
-                  onMouseOver={() => {
-                    showTooltip()
-                  }}
-                  onMouseLeave={() => {
-                    hideTooltip()
-                  }}
-                />
-                &nbsp;
-                {tooltipElement}
-              </div>
-            )
-          }}
-        </Tooltip>
-      )}
-      {checkedBoxes && isDecrypted && (
-        <Checkbox
-          testid={`checkbox-${name}`}
-          checked={checkedBoxes[name]}
-          onClick={e => {
-            e.preventDefault()
-            setCheckedBoxes(prevState => {
-              return { ...prevState, [name]: !prevState[name] }
-            })
-            if (checkedBoxes[name]) {
-              setSelectAll(false)
-            }
+    <ChildDomainItemContainer>
+      {pending && !confirmed ? (
+        <PendingTx
+          txHash={txHash}
+          onConfirmed={() => {
+            setConfirmed()
           }}
         />
+      ) : (
+        <DomainLink
+          showBlockies={showBlockies}
+          data-testid={`${name}`}
+          warning={isMigrated === false ? true : false}
+          key={name}
+          to={`/name/${name}`}
+        >
+          {showBlockies && smallBP && (
+            <SingleNameBlockies imageSize={24} address={owner} />
+          )}
+          <h3>{label}</h3>
+          {canDeleteSubdomain ? (
+            <Bin
+              data-testid={'delete-name'}
+              onClick={e => {
+                e.preventDefault()
+                mutate()
+              }}
+            />
+          ) : (
+            <>
+              <ExpiryDate name={name} expiryDate={expiryDate} />
+              <AddFavourite
+                domain={{ name }}
+                isSubDomain={false}
+                isFavourite={isFavourite}
+              />
+            </>
+          )}
+
+          {!isDecrypted && (
+            <Tooltip
+              text="<p>This name is only partially decoded. If you know the name, you can search for it in the search bar to decrypt it and renew</p>"
+              position="top"
+              border={true}
+              offset={{ left: 0, top: 10 }}
+            >
+              {({ tooltipElement, showTooltip, hideTooltip }) => {
+                return (
+                  <div style={{ position: 'relative' }}>
+                    <QuestionMark
+                      onMouseOver={() => {
+                        showTooltip()
+                      }}
+                      onMouseLeave={() => {
+                        hideTooltip()
+                      }}
+                    />
+                    &nbsp;
+                    {tooltipElement}
+                  </div>
+                )
+              }}
+            </Tooltip>
+          )}
+          {checkedBoxes && isDecrypted && (
+            <Checkbox
+              testid={`checkbox-${name}`}
+              checked={checkedBoxes[name]}
+              onClick={e => {
+                e.preventDefault()
+                setCheckedBoxes(prevState => {
+                  return { ...prevState, [name]: !prevState[name] }
+                })
+                if (checkedBoxes[name]) {
+                  setSelectAll(false)
+                }
+              }}
+            />
+          )}
+        </DomainLink>
       )}
-    </DomainLink>
+    </ChildDomainItemContainer>
   )
 }

--- a/src/components/DomainItem/ChildDomainItem.js
+++ b/src/components/DomainItem/ChildDomainItem.js
@@ -86,7 +86,9 @@ export default function ChildDomainItem({
     label = label + ` (${t('childDomainItem.notmigrated')})`
   const [mutate] = useMutation(DELETE_SUBDOMAIN, {
     onCompleted: data => {
-      startPending(Object.values(data)[0])
+      if (Object.values(data)[0]) {
+        startPending(Object.values(data)[0])
+      }
     },
     variables: {
       name: name

--- a/src/components/DomainItem/ChildDomainItem.js
+++ b/src/components/DomainItem/ChildDomainItem.js
@@ -16,17 +16,23 @@ import { useEditable } from '../hooks'
 import PendingTx from '../PendingTx'
 import AddFavourite from '../AddFavourite/AddFavourite'
 
+const ChildDomainItemContainer = styled('div')`
+  padding: 30px 0;
+  border-bottom: 1px dashed #d3d3d3;
+  &:last-child {
+    border: none;
+  }
+`
+
 const DomainLink = styled(Link)`
   display: grid;
   grid-template-columns: 250px auto 50px;
   grid-gap: 10px;
   width: 100%;
-  padding: 30px 0;
   background-color: ${props => (props.warning ? 'hsla(37,91%,55%,0.1)' : '')};
   color: #2b2b2b;
   font-size: 22px;
   font-weight: 100;
-  border-bottom: 1px dashed #d3d3d3;
 
   ${p =>
     !p.showBlockies &&
@@ -34,10 +40,6 @@ const DomainLink = styled(Link)`
         grid-template-columns: 1fr minmax(150px, 350px) 35px 23px;
         grid-template-rows: 50px
       `}
-
-  &:last-child {
-    border: none;
-  }
 
   span {
     align-self: center;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue number

<!--- If there is an associated github issues, please specify here -->
#1186
#1179

## Description

<!--- Describe your changes in detail -->
The transaction pending message should only disappear once the transaction is complete.

Address page 
When the transaction to set the reverse ENS record is approved in the wallet service, the pending message remains now visible and the reverse record editor is disabled until the transaction is executed.

Name page (subdomain)
The tx pending message is nested in the anchor tag and when trying to delete the subdomain, the tx pending message is clickable. This PR only displays the tx pending message when clicking on the bin until the transaction is executed.

## List of features added/changed

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- Do not trigger `startEditing` handler function on click event as long as tx is pending 
- Set cursor to default on hovering in the `ReverseRecordEditor` when tx pending 
- Do not show pending msg when tx signature is denied (e.g. click "reject" in the Metamask popup)
- Abstract `PendingTx` logic from `DomainLink`
- Encapsulate `PendingTx` and `DomainLink` in a new container that render them conditionally 


## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Run changes against existing unit tests:
![image](https://user-images.githubusercontent.com/53792888/141506950-622705ed-9839-4796-a330-6cac0ce3effd.png)


## Screenshots (if appropriate):

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My code implements all the required features.
