### PR TITLE
Fixed a crash case when there is no account, unsure why.

### DIFF
--- a/src/components/SingleName/DNSNameRegister/DNSNameRegister.js
+++ b/src/components/SingleName/DNSNameRegister/DNSNameRegister.js
@@ -178,7 +178,7 @@ const getContent = (step, account, dnsOwner, t) => {
   }[step]
   if (content.length >= 0) {
     content =
-      dnsOwner.toLowerCase() === account.toLowerCase() ? content[0] : content[1]
+      !!account && dnsOwner.toLowerCase() === account.toLowerCase() ? content[0] : content[1]
   }
   return content
 }


### PR DESCRIPTION
I had a crash occur on the app.ens.domains site when attempting to use a DNS record as an ENS name. I'm not quite sure where the actual error is, but this surfaced as `TypeError: Cannot read properties of undefined (reading 'toLowerCase')` at this line, it seems `account` can sometimes be undefined.

This error presented itself as blanking the entire screen, so not a great user experience. Any attempts to use the site for my DNS record experiences this error, resulting in a blank screen. So this doesn't really solve the problem, but this should hopefully prevent the entire site from crashing to a blank screen.

## Issue number

I think this relates to #1284

## Description

Added a guard so an undefined account doesn't crash the website.

## List of features added/changed

- A guard for if account is undefined.

## How Has This Been Tested?

Nope, I'm making this change blind in Github and hoping ya'll have automated tests.

## Screenshots (if appropriate):

Currently I get a blank screen if the account is undefined, this occurred when I attempted to load what is likely a misconfigured DNS entry.

## Checklist:

- [ ] My code follows the code style of this project. - No idea, I'm making this as a suggestion for where an error occurs more than an actual change.
- [ ] My code implements all the required features. - It possibly fixes my crash, duno if a crash happens later on though.

