### PR TITLE
feat: use Info icon instead of SpeechBubble for about page

### DIFF
--- a/src/components/SideNav/SideNav.js
+++ b/src/components/SideNav/SideNav.js
@@ -13,6 +13,7 @@ import mq from 'mediaQuery'
 import { Link, withRouter } from 'react-router-dom'
 import gql from 'graphql-tag'
 import { isENSReady } from '../../apollo/reactiveVars'
+import Info from 'components/Icons/Info'
 
 const SideNavContainer = styled('nav')`
   display: ${p => (p.isMenuOpen ? 'block' : 'none')};
@@ -184,7 +185,7 @@ function SideNav({ match, isMenuOpen, toggleMenu }) {
         </li>
         <li>
           <ThirdPartyLink href={aboutPageURL()}>
-            <SpeechBubble />
+            <Info />
             <span>{t('c.about')}</span>
           </ThirdPartyLink>
         </li>


### PR DESCRIPTION
## Description

Use Info icon instead of SpeechBubble for about page

## List of features added/changed

`SideNav.js`

## How Has This Been Tested?

Before

![image](https://user-images.githubusercontent.com/69431456/141668297-85339c5c-72df-474c-8c1d-9d27b23b471b.png)

After

![image](https://user-images.githubusercontent.com/69431456/141668294-4fbdb3a9-2db9-445e-aebc-88572995bc7b.png)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My code implements all the required features.
