### PR TITLE
Set input field to empty string after tx approval

### DIFF
--- a/src/components/SingleName/AddSubdomain.js
+++ b/src/components/SingleName/AddSubdomain.js
@@ -53,7 +53,10 @@ function AddSubdomain({ domain, refetch }) {
   const isInvalid = !isValid && newValue.length > 0
   const [mutation] = useMutation(CREATE_SUBDOMAIN, {
     onCompleted: data => {
-      startPending(Object.values(data)[0])
+      if (data) {
+        startPending(Object.values(data)[0])
+        updateValue('')
+      }
     }
   })
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue number
#1343 

<!--- If there is an associated github issues, please specify here -->

## Description

<!--- Describe your changes in detail -->
This PR resets the value of the input field to an empty string after confirming the transaction to create a subdomain.

## List of features added/changed

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- set `newValue` state to an empty string in the callback function triggered when mutation successfully completes
- Do not show pending msg or reset the state when tx signature is denied (e.g. click "reject" in the Metamask popup)

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Run changes against existing unit tests:
![image](https://user-images.githubusercontent.com/53792888/141682798-591b3eac-97d7-4256-b4f8-484a296801cd.png)


## Screenshots (if appropriate):

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My code implements all the required features.
