### PR TITLE
Refetch list of subdomains after deletion

### DIFF
--- a/src/components/DomainItem/ChildDomainItem.js
+++ b/src/components/DomainItem/ChildDomainItem.js
@@ -74,7 +74,8 @@ export default function ChildDomainItem({
   setCheckedBoxes,
   setSelectAll,
   showBlockies = true,
-  canDeleteSubdomain
+  canDeleteSubdomain,
+  refetch
 }) {
   const { state, actions } = useEditable()
   const { txHash, pending, confirmed } = state
@@ -104,6 +105,7 @@ export default function ChildDomainItem({
           txHash={txHash}
           onConfirmed={() => {
             setConfirmed()
+            refetch()
           }}
         />
       ) : (

--- a/src/components/SingleName/SubDomains.js
+++ b/src/components/SingleName/SubDomains.js
@@ -77,6 +77,7 @@ function SubDomainsFromWeb3({ domain, canAddSubdomain }) {
                   owner={d.owner}
                   labelhash={d.labelHash}
                   canDeleteSubdomain={canAddSubdomain}
+                  refetch={refetch}
                 />
               ))}
           </>
@@ -199,6 +200,7 @@ function SubDomains({
                       labelhash={d.labelHash}
                       isSubdomain={true}
                       canDeleteSubdomain={canAddSubdomain}
+                      refetch={refetch}
                     />
                   )
                 })}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue number
#1345

<!--- If there is an associated github issues, please specify here -->

## Description

<!--- Describe your changes in detail -->
Refetch the subdomains queries in response to a successful subdomain deletion.

## List of features added/changed

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- Pass refetch function from Query component as a prop to `SubDomainsFromWeb3` and `SubDomains`
- Call refetch function once subdomain deletion tx is successfully executed 

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Run changes against existing unit tests:
![image](https://user-images.githubusercontent.com/53792888/142070949-fe62c28f-d850-4ba4-9e28-ea06a39800b7.png)

## Screenshots (if appropriate):
N/A

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My code implements all the required features.
