### PR TITLE
Remove preivew branch creation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,16 +60,16 @@ jobs:
         - yarn --frozen-lockfile
       script:
         - yarn test:coverage
-    - stage: test
-      name: 'Branch Preview'
-      install:
-        - yarn install
-      script:
-        - npm run build
-        - npm run postbuild
-        - pwd
-        - ls
-        - surge build "$TRAVIS_BRANCH"-ensdev.surge.sh
+    #    - stage: test
+    #      name: 'Branch Preview'
+    #      install:
+    #        - yarn install
+    #      script:
+    #        - npm run build
+    #        - npm run postbuild
+    #        - pwd
+    #        - ls
+    #        - surge build "$TRAVIS_BRANCH"-ensdev.surge.sh
     - stage: test
       name: 'Cleanup Previews'
       install:


### PR DESCRIPTION
Some builds are failing on preview branch creation. It is not worth fixing now as we will soon get them for free once we move to netlify.