### PR TITLE
Allow previous registrants to reregister expired domains

### DIFF
--- a/src/components/SingleName/Name.js
+++ b/src/components/SingleName/Name.js
@@ -29,8 +29,8 @@ const RightBar = styled('div')`
 
 const Favourite = styled(DefaultFavourite)``
 
-function isRegistrationOpen(available, parent, isDeedOwner) {
-  return parent === 'eth' && !isDeedOwner && available
+function isRegistrationOpen(available, parent) {
+  return parent === 'eth' && available
 }
 
 function isDNSRegistrationOpen(domain) {
@@ -88,11 +88,7 @@ function Name({ details: domain, name, pathname, type, refetch }) {
   const isDeedOwner = domain.deedOwner === account
   const isRegistrant = !domain.available && domain.registrant === account
 
-  const registrationOpen = isRegistrationOpen(
-    domain.available,
-    domain.parent,
-    isDeedOwner
-  )
+  const registrationOpen = isRegistrationOpen(domain.available, domain.parent)
   const preferredTab = registrationOpen ? 'register' : 'details'
 
   let ownerType,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue number

closes https://github.com/ensdomains/ens-app/issues/928

<!--- If there is an associated github issues, please specify here -->

## Description

Currently, an expired domain cannot be reregistered by the same owner.
This limitation is because the `isDeedOwner` check makes the
registration availability come back false for the previous registrant.

I'd love to be able to reregister domains I lost track of ;)

This change removes the isDeedOwner check from this logic. There may
unintended consequences of this change and I am not sure
how best to test this change. I am very open to feedback. Thanks!


<!--- Describe your changes in detail -->

## List of features added/changed

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- An account who previously registered a domain that is currently expired can now reregister the domain again.

## How Has This Been Tested?

Locally, I was able to see the registration UI for a domain that was previously registered but now expired.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

Before the change:

![image](https://user-images.githubusercontent.com/2181356/143126829-ebf6a854-bd22-46e7-a988-3453819716dd.png)


After the change:

![image](https://user-images.githubusercontent.com/2181356/143125455-96b409cb-efb7-4dc8-9fed-e1d15a04a004.png)


## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] My code follows the code style of this project.
- [X] My code implements all the required features.
