### PR TITLE
fix: center align OrangeExclamation icon and message in prompt

### DIFF
--- a/src/components/SingleName/Pricer.js
+++ b/src/components/SingleName/Pricer.js
@@ -30,12 +30,15 @@ const Chain = styled(ChainDefault)`
 `
 
 const OrangeExclamation = styled(DefaultOrangeExclamation)`
-  height: 12px;
-  width: 12px;
+  height: 14px;
+  width: 14px;
+  margin-right: 2px;
 `
 
 const Prompt = styled('div')`
   color: #ffa600;
+  display: flex;
+  align-items: center;
   margin-bottom: 10px;
 `
 
@@ -60,7 +63,7 @@ function PricerInner({
       {years <= 1 && (
         <Prompt>
           <OrangeExclamation />
-          {t('register.increaseRegistrationPeriod')}
+          <div>{t('register.increaseRegistrationPeriod')}</div>
         </Prompt>
       )}
       <PricingContainer className={className} ref={reference}>


### PR DESCRIPTION
## Description

fix: center align OrangeExclamation icon and message in prompt

## Screenshots (if appropriate):

Before

![image](https://user-images.githubusercontent.com/69431456/143431780-c7e5f772-0362-4f6e-84c2-ed8a7161993b.png)

After

![image](https://user-images.githubusercontent.com/69431456/143431715-68a8c6c0-d6f3-412f-b223-97b6db31b705.png)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My code implements all the required features.
