### PR TITLE
Add img alternative text

### DIFF
--- a/src/components/Banner/DAOBanner.js
+++ b/src/components/Banner/DAOBanner.js
@@ -97,14 +97,14 @@ export function DAOBannerContent() {
       rel="noreferrer"
       href="https://ens.mirror.xyz/5cGl-Y37aTxtokdWk21qlULmE1aSM_NuX9fstbOPoWU"
     >
-      <LogoSmall src={ENSIcon} />
+      <LogoSmall src={ENSIcon} alt="ENS logo" />
       <div>
         <BannerTitle>$ENS Now Available for Claiming.</BannerTitle>
         <BannerContent>
           Claim your $ENS and participate in ENS governance.
         </BannerContent>
       </div>
-      <ArrowSmall src={Arrow} />
+      <ArrowSmall src={Arrow} alt="Arrow right icon" />
     </Link>
   )
 }

--- a/src/routes/Home.js
+++ b/src/routes/Home.js
@@ -351,6 +351,7 @@ export default ({ match }) => {
             initial={animation.initial}
             animate={animation.animate}
             src={ENSLogo}
+            alt="ENS logo"
           />
           <PermanentRegistrarLogo
             initial={animation.initial}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue number
#1368
<!--- If there is an associated github issues, please specify here -->

## Description
Alternative text is missing on ENS icons and the arrow img on the banner (home page) causing some screen readers to read the value of the `src` attribute aloud. 

<!--- Describe your changes in detail -->

## List of features added/changed

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- Added an alt attribute to `LogoSmall`, `LogoLarge` and `ArrowSmall` components 

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Tested with the Orca screen reader from the GNOME project (version 3.36.2).
## Screenshots (if appropriate):
Before:
![image](https://user-images.githubusercontent.com/53792888/143449924-9a04a93b-28e9-480d-8ec7-8824b6f560e3.png)

After:
![image](https://user-images.githubusercontent.com/53792888/143449956-0c0e4ddc-613a-49c9-b121-f32b7f0d3a9c.png)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My code implements all the required features.
