### PR TITLE
Increase max-width registration period input

### DIFF
--- a/src/components/SingleName/NameRegister/Years.js
+++ b/src/components/SingleName/NameRegister/Years.js
@@ -45,7 +45,7 @@ const Icon = styled('div')`
 
 const Amount = styled('div')`
   width: 150px;
-  padding-left: 20px;
+  padding: 0 5px;
   display: flex;
   font-family: Overpass;
   font-size: 28px;
@@ -61,8 +61,9 @@ const Amount = styled('div')`
     font-weight: 100;
     color: #2b2b2b;
     border: none;
-    max-width: 45px;
+    max-width: 65px;
     outline: 0;
+    text-align: center;
   }
 `
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue number
#1358
<!--- If there is an associated github issues, please specify here -->

## Description

<!--- Describe your changes in detail -->
When the content of the registration period input is too big to fit in the element, the overflow is clipped. This PR increases the value of the `max-width` property to allow the number of years to go up to 4 digits so that there is no overflow anymore.

I left the content of the `Amount` component left aligned horizontally. I can also center it if you'd prefer.
![image](https://user-images.githubusercontent.com/53792888/143492853-46410162-ad3e-4b28-9e64-9a258f5cdcc0.png)

## List of features added/changed

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- `max-width` property increased by `20px`
- content of the input element centered 
- padding adjusted to be symmetrical

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Simulated the viewport on different mobile devices and on desktop. Also tested with all the languages currently available in the manager app.

## Screenshots (if appropriate):
Before:
![image](https://user-images.githubusercontent.com/53792888/143492751-058af39f-a4b5-445a-bf97-07461bcbb5f8.png)

After:
![image](https://user-images.githubusercontent.com/53792888/143492795-17a129f0-aa1f-4b39-931c-c02cbc3c084a.png)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My code implements all the required features.
