### PR TITLE
Add primary name status clarity on address page

### DIFF
--- a/src/components/AddReverseRecord.js
+++ b/src/components/AddReverseRecord.js
@@ -56,7 +56,7 @@ const Message = styled('div')`
   font-family: Overpass Mono;
   font-weight: 700;
   font-size: 14px;
-  color: #adbbcd;
+  color: ${p => (p.nameSet ? '#747f8c' : '#adbbcd')};
   letter-spacing: 0;
   display: flex;
   align-items: center;
@@ -147,8 +147,9 @@ function AddReverseRecord({ account, currentAddress }) {
   })
 
   useEffect(() => {
-    startEditing()
-  }, [getReverseRecord, account])
+    if (!getReverseRecord) return
+    if (!hasValidReverseRecord(getReverseRecord)) return startEditing()
+  }, [loading])
 
   const {
     data: { networkId }
@@ -221,6 +222,7 @@ function AddReverseRecord({ account, currentAddress }) {
               : startEditing()
           }
           pending={pending}
+          nameSet={hasValidReverseRecord(getReverseRecord)}
         >
           {hasValidReverseRecord(getReverseRecord) ? (
             <MessageContent data-testid="editable-reverse-record-set">


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
A reasonably significant amount of users get confused about if they have a primary name set or not on their address page, which leads some to send a transaction multiple times for doing so. This PR clarifies that confusion.

## List of features added/changed
+ Stop primary name edit box from being opened automatically if the user has one set
+ Set the primary name message colour to be darker if the user has one set

## How Has This Been Tested?
As it's a very small change, it's just been tested in a browser manually. 

## Screenshots:

| Before (With primary name set, on page load) | After (With primary name set, on page load) |
| ----------- | ----------- |
| ![Screenshot 2021-11-26 161359](https://user-images.githubusercontent.com/11844316/143531090-badd41d1-983a-4e0a-892f-d41e531c8de5.png) | ![image](https://user-images.githubusercontent.com/11844316/143531063-f9803d66-551a-4e3a-80df-0e51239fc876.png) |


## Checklist:
- [x] My code follows the code style of this project.
- [x] My code implements all the required features.
