### PR TITLE
Fix Safe App connection

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@ensdomains/react-ens-address": "^0.0.30",
     "@ensdomains/ui": "^3.3.11",
     "@ensdomains/web3modal": "1.9.4",
-    "@gnosis.pm/safe-apps-provider": "^0.2.2",
+    "@gnosis.pm/safe-apps-provider": "^0.9.2",
     "@myetherwallet/mewconnect-web-client": "^2.1.11",
     "@portis/web3": "^2.0.0-beta.59",
     "@toruslabs/torus-embed": "^1.8.6",

--- a/src/utils/safeApps.js
+++ b/src/utils/safeApps.js
@@ -13,21 +13,23 @@ export function isRunningAsSafeApp() {
 export const safeInfo = async () => {
   try {
     return await Promise.race([
-      safeAppsSdk.getSafeInfo(),
-      new Promise(resolve => setTimeout(resolve, 100))
+      safeAppsSdk.safe.getInfo(),
+      new Promise(resolve => setTimeout(resolve, 200))
     ])
   } catch (e) {
+    console.error(e)
     return undefined
   }
 }
 
 export const setupSafeApp = async safeInfo => {
   const provider = new SafeAppProvider(safeInfo, safeAppsSdk)
-  await setupENS({
+  const { providerObject } = await setupENS({
     customProvider: provider,
     reloadOnAccountsChange: true,
     enforceReload: true
   })
   isSafeAppSetup = true
-  return await getNetwork()
+
+  return providerObject
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2291,19 +2291,28 @@
   resolved "https://registry.yarnpkg.com/@gar/promisify/-/promisify-1.1.2.tgz#30aa825f11d438671d585bd44e7fd564535fc210"
   integrity sha512-82cpyJyKRoQoRi+14ibCeGPu0CwypgtBAdBhq1WfvagpCZNKqwXbKwXllYSMG91DhmG4jt9gN8eP6lGOtozuaw==
 
-"@gnosis.pm/safe-apps-provider@^0.2.2":
-  version "0.2.4"
-  resolved "https://registry.yarnpkg.com/@gnosis.pm/safe-apps-provider/-/safe-apps-provider-0.2.4.tgz#5d78a0954791aa01344afdb701886fe5d3077905"
-  integrity sha512-C9JrY/UAU0I6GO3YoI2w/uTxoNiU3AlH2ou/1SrXW6W1f8oBnG0sb3LbYlko16TsGCc1CGTKzGb6aD2e6a45Vg==
+"@gnosis.pm/safe-apps-provider@^0.9.2":
+  version "0.9.2"
+  resolved "https://registry.yarnpkg.com/@gnosis.pm/safe-apps-provider/-/safe-apps-provider-0.9.2.tgz#79b458dc1e3ace98c8e4e5d0ec51ced5674ca5ad"
+  integrity sha512-U29BjGzGG6+8uzKrWpmowKl8bkexeXu/9xpadlGFTDvd3Xrd3BdSCLVpLwKsYJ5uGNE4Ex/yRdHuXsZCw5iDug==
   dependencies:
-    "@gnosis.pm/safe-apps-sdk" "2.2.0"
+    "@gnosis.pm/safe-apps-sdk" "6.1.1"
+    events "^3.3.0"
 
-"@gnosis.pm/safe-apps-sdk@2.2.0":
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/@gnosis.pm/safe-apps-sdk/-/safe-apps-sdk-2.2.0.tgz#aaaeb74d122816407fb2ac4333322355891ac774"
-  integrity sha512-4CCrTfCAGrT1NiYpOs22B/YSycEymC6lxO5h37H8LFC9WNjUijhrxsQZiu7rPzDE9VDXe6s2YOiaGgKCthoorA==
+"@gnosis.pm/safe-apps-sdk@6.1.1":
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/@gnosis.pm/safe-apps-sdk/-/safe-apps-sdk-6.1.1.tgz#6a4e19c475967a0d04a8c04559e05703484e2ca8"
+  integrity sha512-MI2gIdQUlu1NrDt5rF47xey1LSiQoy5Nb+vqn16PM5qVc3FjR+nPNG8+1yGlL96di31z+kyS2J8DzHiea7+TMA==
   dependencies:
-    semver "^7.3.2"
+    "@gnosis.pm/safe-react-gateway-sdk" "^2.5.6"
+    ethers "^5.4.7"
+
+"@gnosis.pm/safe-react-gateway-sdk@^2.5.6":
+  version "2.5.7"
+  resolved "https://registry.yarnpkg.com/@gnosis.pm/safe-react-gateway-sdk/-/safe-react-gateway-sdk-2.5.7.tgz#19afe10167de9ae295e74d394993c9c3f41dcef2"
+  integrity sha512-UWatVpxScf/SduARLFHrR2nzupLCtHsT+aWjF7uaHmObs88MEr1RMesQH8h1ljWWX3bKYb5PpRlblW93unkKKg==
+  dependencies:
+    isomorphic-unfetch "^3.1.0"
 
 "@graphql-typed-document-node/core@^3.0.0":
   version "3.1.0"
@@ -12778,6 +12787,14 @@ isomorphic-fetch@^2.2.1:
     node-fetch "^1.0.1"
     whatwg-fetch ">=0.10.0"
 
+isomorphic-unfetch@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/isomorphic-unfetch/-/isomorphic-unfetch-3.1.0.tgz#87341d5f4f7b63843d468438128cb087b7c3e98f"
+  integrity sha512-geDJjpoZ8N0kWexiwkX8F9NkTsXhetLPVbZFQ+JTW239QNOwvB0gniuR1Wc6f0AMTn7/mFGyXvHTifrCp/GH8Q==
+  dependencies:
+    node-fetch "^2.6.1"
+    unfetch "^4.2.0"
+
 isomorphic-ws@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/isomorphic-ws/-/isomorphic-ws-4.0.1.tgz#55fd4cd6c5e6491e76dc125938dd863f5cd4f2dc"
@@ -21161,6 +21178,11 @@ underscore@^1.8.3, underscore@latest:
   version "1.13.1"
   resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.13.1.tgz#0c1c6bd2df54b6b69f2314066d65b6cde6fcf9d1"
   integrity sha512-hzSoAVtJF+3ZtiFX0VgfFPHEDRm7Y/QPjGyNo4TVdnDTdft3tr8hEkD25a1jC+TjTuE7tkHGKkhwCgs9dgBB2g==
+
+unfetch@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/unfetch/-/unfetch-4.2.0.tgz#7e21b0ef7d363d8d9af0fb929a5555f6ef97a3be"
+  integrity sha512-F9p7yYCn6cIW9El1zi0HI6vqpeIvBsr3dSuRO6Xuppb1u5rXpCPmMvLSyECLhybr9isec8Ohl0hPekMVrEinDA==
 
 unicode-canonical-property-names-ecmascript@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue number 1332

#1332 

## Description

Fixes connection to the Safe interface by using a correct method to retrieve Safe information, adds error logging for the future, and also fixing returns in `setupSafeApp`(it returned network info, but the users of this function expected a provider)

Also, the PR bumps `safe-apps-provider` version

## List of bugs fixed

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Fixes connection to the Safe interface when loaded as a Safe app

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

I ran the Safe and ENS App locally, and when I loaded the ENS app, it could connect to the interface and display Safe address.

## Screenshots (if appropriate):

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My code implements all the required features.
