### PR TITLE
Add avatar record validation

### DIFF
--- a/src/api/avatar.js
+++ b/src/api/avatar.js
@@ -6,13 +6,21 @@ export default async function validateTokenURI(value, addr) {
   // basic validity checks
   if (value.split('/').length !== 3) return false
   if (details[0] !== 'eip155:1') return false
+  if (!details[2]) return false
 
   const [schema, contractAddress] = details[1].split(':')
-  const tokenId = ethers.BigNumber.from(details[2])
+
+  try {
+    details[2] = ethers.BigNumber.from(details[2])
+  } catch {
+    details[2] = false
+  }
+
+  const tokenId = ethers.BigNumber.isBigNumber(details[2]) && details[2]
 
   // token/contract checks
   if (schema !== 'erc721' && schema !== 'erc1155') return false
-  if (isNaN(tokenId)) return false
+  if (!tokenId) return false
 
   try {
     const network = await getNetworkId()
@@ -30,6 +38,8 @@ export default async function validateTokenURI(value, addr) {
             'function balanceOf(address account, uint256 id) public view returns (uint256)'
           ]
     const contract = new ethers.Contract(contractAddress, ABI, provider)
+
+    console.log('passed 3')
 
     // if there is token metadata, and the owner of the token is the address for name, return as valid
     if (schema === 'erc721') {

--- a/src/api/avatar.js
+++ b/src/api/avatar.js
@@ -10,17 +10,16 @@ export default async function validateTokenURI(value, addr) {
 
   const [schema, contractAddress] = details[1].split(':')
 
+  // check tokenId is valid
+  let tokenId
   try {
-    details[2] = ethers.BigNumber.from(details[2])
+    tokenId = ethers.BigNumber.from(details[2])
   } catch {
-    details[2] = false
+    return false
   }
-
-  const tokenId = ethers.BigNumber.isBigNumber(details[2]) && details[2]
 
   // token/contract checks
   if (schema !== 'erc721' && schema !== 'erc1155') return false
-  if (!tokenId) return false
 
   try {
     const network = await getNetworkId()
@@ -38,8 +37,6 @@ export default async function validateTokenURI(value, addr) {
             'function balanceOf(address account, uint256 id) public view returns (uint256)'
           ]
     const contract = new ethers.Contract(contractAddress, ABI, provider)
-
-    console.log('passed 3')
 
     // if there is token metadata, and the owner of the token is the address for name, return as valid
     if (schema === 'erc721') {

--- a/src/api/avatar.js
+++ b/src/api/avatar.js
@@ -1,0 +1,49 @@
+import { ethers, getNetworkId, getNetworkProviderUrl } from '@ensdomains/ui'
+
+export default async function validateTokenURI(value, addr) {
+  const details = value.split('/')
+
+  // basic validity checks
+  if (value.split('/').length !== 3) return false
+  if (details[0] !== 'eip155:1') return false
+
+  const [schema, contractAddress] = details[1].split(':')
+  const tokenId = parseInt(details[2])
+
+  // token/contract checks
+  if (schema !== 'erc721' && schema !== 'erc1155') return false
+  if (isNaN(tokenId)) return false
+
+  try {
+    const network = await getNetworkId()
+    const networkProvider = getNetworkProviderUrl(`${network}`)
+    const provider = new ethers.providers.JsonRpcProvider(networkProvider)
+    // set functions needed to check validity of ownership/NFT compatibility
+    const ABI =
+      schema === 'erc721'
+        ? [
+            'function tokenURI(uint256 tokenId) external view returns (string memory)',
+            'function ownerOf(uint256 tokenId) public view returns (address)'
+          ]
+        : [
+            'function uri(uint256 _id) public view returns (string memory)',
+            'function balanceOf(address account, uint256 id) public view returns (uint256)'
+          ]
+    const contract = new ethers.Contract(contractAddress, ABI, provider)
+
+    // if there is token metadata, and the owner of the token is the address for name, return as valid
+    if (schema === 'erc721') {
+      const tokenURI = await contract.tokenURI(tokenId)
+      const ownerOf = await contract.ownerOf(tokenId)
+      if (tokenURI && ownerOf === addr) return true
+    } else {
+      const uri = await contract.uri(tokenId)
+      const balanceOf = await contract.balanceOf(addr, tokenId)
+      if (uri && balanceOf > 0) return true
+    }
+    return false
+  } catch (e) {
+    console.warn(e)
+    return false
+  }
+}

--- a/src/api/avatar.js
+++ b/src/api/avatar.js
@@ -8,7 +8,7 @@ export default async function validateTokenURI(value, addr) {
   if (details[0] !== 'eip155:1') return false
 
   const [schema, contractAddress] = details[1].split(':')
-  const tokenId = parseInt(details[2])
+  const tokenId = ethers.BigNumber.from(details[2])
 
   // token/contract checks
   if (schema !== 'erc721' && schema !== 'erc1155') return false

--- a/src/api/avatar.js
+++ b/src/api/avatar.js
@@ -1,6 +1,6 @@
 import { ethers, getNetworkId, getNetworkProviderUrl } from '@ensdomains/ui'
 
-export default async function validateTokenURI(value, addr) {
+export default function validateTokenURI(value, addr) {
   const details = value.split('/')
 
   // basic validity checks
@@ -21,36 +21,36 @@ export default async function validateTokenURI(value, addr) {
   // token/contract checks
   if (schema !== 'erc721' && schema !== 'erc1155') return false
 
-  try {
-    const network = await getNetworkId()
-    const networkProvider = getNetworkProviderUrl(`${network}`)
-    const provider = new ethers.providers.JsonRpcProvider(networkProvider)
-    // set functions needed to check validity of ownership/NFT compatibility
-    const ABI =
-      schema === 'erc721'
-        ? [
-            'function tokenURI(uint256 tokenId) external view returns (string memory)',
-            'function ownerOf(uint256 tokenId) public view returns (address)'
-          ]
-        : [
-            'function uri(uint256 _id) public view returns (string memory)',
-            'function balanceOf(address account, uint256 id) public view returns (uint256)'
-          ]
-    const contract = new ethers.Contract(contractAddress, ABI, provider)
+  return new Promise(async resolve => {
+    try {
+      const network = await getNetworkId()
+      const networkProvider = getNetworkProviderUrl(`${network}`)
+      const provider = new ethers.providers.JsonRpcProvider(networkProvider)
+      // set functions needed to check validity of ownership/NFT compatibility
+      const ABI =
+        schema === 'erc721'
+          ? [
+              'function tokenURI(uint256 tokenId) external view returns (string memory)',
+              'function ownerOf(uint256 tokenId) public view returns (address)'
+            ]
+          : [
+              'function uri(uint256 _id) public view returns (string memory)',
+              'function balanceOf(address account, uint256 id) public view returns (uint256)'
+            ]
+      const contract = new ethers.Contract(contractAddress, ABI, provider)
 
-    // if there is token metadata, and the owner of the token is the address for name, return as valid
-    if (schema === 'erc721') {
-      const tokenURI = await contract.tokenURI(tokenId)
-      const ownerOf = await contract.ownerOf(tokenId)
-      if (tokenURI && ownerOf === addr) return true
-    } else {
-      const uri = await contract.uri(tokenId)
-      const balanceOf = await contract.balanceOf(addr, tokenId)
-      if (uri && balanceOf > 0) return true
+      // if there is token metadata, return as valid
+      if (schema === 'erc721') {
+        const tokenURI = await contract.tokenURI(tokenId)
+        if (tokenURI) resolve(true)
+      } else {
+        const uri = await contract.uri(tokenId)
+        if (uri) resolve(true)
+      }
+      resolve(false)
+    } catch (e) {
+      console.warn(e)
+      resolve(false)
     }
-    return false
-  } catch (e) {
-    console.warn(e)
-    return false
-  }
+  })
 }

--- a/src/components/SingleName/ResolverAndRecords/AddRecord.js
+++ b/src/components/SingleName/ResolverAndRecords/AddRecord.js
@@ -157,7 +157,7 @@ const validate = async (selectedKey, newValue, selectedRecord, domain) => {
     key: selectedKey?.value,
     value: newValue,
     contractFn: selectedRecord?.contractFn,
-    domain
+    addr: domain.addr
   })
 }
 

--- a/src/components/SingleName/ResolverAndRecords/KeyValueRecord/KeyValueRecord.js
+++ b/src/components/SingleName/ResolverAndRecords/KeyValueRecord/KeyValueRecord.js
@@ -117,7 +117,7 @@ const Editable = ({
             type="text"
             isInvalid={!isValid && !isValidating}
             onChange={event => {
-              updateRecord({ ...record, value: event.target.value, domain })
+              updateRecord({ ...record, value: event.target.value })
             }}
             value={value === emptyAddress ? '' : value}
             isValid={isValid && !isValidating}

--- a/src/components/SingleName/ResolverAndRecords/KeyValueRecord/KeyValueRecord.js
+++ b/src/components/SingleName/ResolverAndRecords/KeyValueRecord/KeyValueRecord.js
@@ -100,10 +100,12 @@ const Editable = ({
   changedRecords,
   updateRecord,
   record,
-  placeholder
+  placeholder,
+  validating
 }) => {
   const { key, value } = record
   const isValid = validator(record)
+  const isValidating = validating(record)
   return (
     <KeyValueItem editing={editing} hasRecord={true} noBorder>
       {editing ? (
@@ -113,12 +115,13 @@ const Editable = ({
             testId={`${key}-record-input`}
             hasBeenUpdated={hasChange(changedRecords, key)}
             type="text"
-            isInvalid={!isValid}
+            isInvalid={!isValid && !isValidating}
             onChange={event => {
-              updateRecord({ ...record, value: event.target.value })
+              updateRecord({ ...record, value: event.target.value, domain })
             }}
             value={value === emptyAddress ? '' : value}
-            {...{ placeholder, isValid }}
+            isValid={isValid && !isValidating}
+            {...{ placeholder }}
           />
 
           <Bin
@@ -150,7 +153,8 @@ function Record(props) {
     changedRecords,
     updateRecord,
     record,
-    domain
+    domain,
+    validating
   } = props
 
   const { key, value } = record
@@ -165,6 +169,7 @@ function Record(props) {
     <Editable
       {...props}
       validator={validator}
+      validating={validating}
       editing={editing}
       setUpdatedRecords={setUpdatedRecords}
       changedRecords={changedRecords}
@@ -200,7 +205,8 @@ function Records({
   changedRecords,
   recordType,
   updateRecord,
-  domain
+  domain,
+  validating
 }) {
   const [hasRecord, setHasRecord] = useState(false)
   return (
@@ -213,6 +219,7 @@ function Records({
               editing={editing}
               dataValue={record.value}
               validator={validator}
+              validating={validating}
               setHasRecord={setHasRecord}
               hasRecord={hasRecord}
               canEdit={canEdit}

--- a/src/components/SingleName/ResolverAndRecords/Records.js
+++ b/src/components/SingleName/ResolverAndRecords/Records.js
@@ -325,7 +325,6 @@ const throttledUpdate = throttle(
     updatedRecordDiff
   ) => {
     setChangedRecords(getChangedRecords(initialRecords, updatedRecords))
-    console.log(updatedRecordDiff)
     const newValidRecords = await getValidRecords(
       updatedRecordDiff,
       validateRecord

--- a/src/components/SingleName/ResolverAndRecords/Records.js
+++ b/src/components/SingleName/ResolverAndRecords/Records.js
@@ -206,20 +206,21 @@ const getInitialCoins = dataAddresses => {
   }))
 }
 
-const getInitialTextRecords = dataTextRecords => {
+const getInitialTextRecords = (dataTextRecords, domain) => {
   const textRecords =
     dataTextRecords && dataTextRecords.getTextRecords
       ? processRecords(dataTextRecords.getTextRecords, TEXT_PLACEHOLDER_RECORDS)
       : processRecords([], TEXT_PLACEHOLDER_RECORDS)
 
   return textRecords?.map(textRecord => ({
+    addr: domain.addr,
     contractFn: 'setText',
     ...textRecord
   }))
 }
 
 const getInitialRecords = (domain, dataAddresses, dataTextRecords) => {
-  const initialTextRecords = getInitialTextRecords(dataTextRecords)
+  const initialTextRecords = getInitialTextRecords(dataTextRecords, domain)
   const initialCoins = getInitialCoins(dataAddresses)
   const initialContent = getInitialContent(domain)
 
@@ -324,6 +325,7 @@ const throttledUpdate = throttle(
     updatedRecordDiff
   ) => {
     setChangedRecords(getChangedRecords(initialRecords, updatedRecords))
+    console.log(updatedRecordDiff)
     const newValidRecords = await getValidRecords(
       updatedRecordDiff,
       validateRecord

--- a/src/components/SingleName/ResolverAndRecords/Records.js
+++ b/src/components/SingleName/ResolverAndRecords/Records.js
@@ -354,7 +354,6 @@ const useChangedValidRecords = (
       const updatedRecordDiff = updatedRecords.filter(
         record => !prevUpdatedRecords.includes(record)
       )
-      console.log(updatedRecordDiff)
       throttledUpdate(
         setChangedRecords,
         initialRecords,

--- a/src/utils/records.js
+++ b/src/utils/records.js
@@ -3,7 +3,7 @@ import { addressUtils, supportedAvatarProtocols } from 'utils/utils'
 import { formatsByName } from '@ensdomains/address-encoder'
 import validateTokenURI from 'api/avatar'
 
-export async function validateRecord({ key, value, contractFn, domain }) {
+export async function validateRecord({ key, value, contractFn, addr }) {
   if (!value) return true
   switch (contractFn) {
     case 'setContenthash':
@@ -20,8 +20,7 @@ export async function validateRecord({ key, value, contractFn, domain }) {
         value.startsWith(proto)
       )
       if (!protocol) return false
-      if (protocol === 'eip155')
-        return await validateTokenURI(value, domain.addr)
+      if (protocol === 'eip155') return await validateTokenURI(value, addr)
       return true
     case 'setAddr(bytes32,uint256,bytes)':
       if (value === '') return false

--- a/src/utils/records.js
+++ b/src/utils/records.js
@@ -1,8 +1,9 @@
 import { encodeContenthash, isValidContenthash } from '@ensdomains/ui'
-import { addressUtils } from 'utils/utils'
+import { addressUtils, supportedAvatarProtocols } from 'utils/utils'
 import { formatsByName } from '@ensdomains/address-encoder'
+import validateTokenURI from 'api/avatar'
 
-export function validateRecord({ key, value, contractFn }) {
+export async function validateRecord({ key, value, contractFn, domain }) {
   if (!value) return true
   switch (contractFn) {
     case 'setContenthash':
@@ -14,6 +15,13 @@ export function validateRecord({ key, value, contractFn }) {
         return false
       }
     case 'setText':
+      if (key !== 'avatar') return true
+      const protocol = supportedAvatarProtocols.find(proto =>
+        value.startsWith(proto)
+      )
+      if (!protocol) return false
+      if (protocol === 'eip155')
+        return await validateTokenURI(value, domain.addr)
       return true
     case 'setAddr(bytes32,uint256,bytes)':
       if (value === '') return false

--- a/src/utils/records.js
+++ b/src/utils/records.js
@@ -3,7 +3,7 @@ import { addressUtils, supportedAvatarProtocols } from 'utils/utils'
 import { formatsByName } from '@ensdomains/address-encoder'
 import validateTokenURI from 'api/avatar'
 
-export async function validateRecord({ key, value, contractFn, addr }) {
+export function validateRecord({ key, value, contractFn, addr }) {
   if (!value) return true
   switch (contractFn) {
     case 'setContenthash':
@@ -20,7 +20,7 @@ export async function validateRecord({ key, value, contractFn, addr }) {
         value.startsWith(proto)
       )
       if (!protocol) return false
-      if (protocol === 'eip155') return await validateTokenURI(value, addr)
+      if (protocol === 'eip155') return validateTokenURI(value, addr)
       return true
     case 'setAddr(bytes32,uint256,bytes)':
       if (value === '') return false

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -16,6 +16,7 @@ import * as jsSHA3 from 'js-sha3'
 import { saveName } from '../api/labels'
 import { useEffect, useRef } from 'react'
 import { EMPTY_ADDRESS } from './records'
+import { throttle } from 'lodash'
 
 // From https://github.com/0xProject/0x-monorepo/blob/development/packages/utils/src/address_utils.ts
 
@@ -278,4 +279,16 @@ export function isCID(hash) {
   } catch (e) {
     return false
   }
+}
+
+export function asyncThrottle(func, wait) {
+  const throttled = throttle((resolve, reject, args) => {
+    func(...args)
+      .then(resolve)
+      .catch(reject)
+  }, wait)
+  return (...args) =>
+    new Promise((resolve, reject) => {
+      throttled(resolve, reject, args)
+    })
 }


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
Quite a few users have used a significant amount of gas on setting their avatar record to fields that are either incorrectly formatted, or using NFTs that they don't own/don't have a tokenURI. This PR adds validation to the avatar field with basic checks in place, to ensure a user doesn't accidentally enter incorrect information.

## List of features added/changed

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Record validation changed to be asynchronous (to allow querying contracts).
- [x] Records can be in a "validating" state, and displays to user by removing the tick and error icons until validated.
- [x] Records are now only validated when they are changed, instead of all records being validated for every change.
- [x] Avatar text record now has specific validation to query whether it meets requirements for ENS avatars.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
All unit tests passed

## Checklist:

- [x] My code follows the code style of this project.
- [x] My code implements all the required features.
