### PR TITLE
Add aria labels

### DIFF
--- a/src/components/Links/AddressLink.js
+++ b/src/components/Links/AddressLink.js
@@ -9,8 +9,12 @@ const AddressLinkContainer = styled(Link)`
   font-family: Overpass Mono;
 `
 
-const AddressLink = ({ children, address, className }) => (
-  <AddressLinkContainer to={`/address/${address}`} className={className}>
+const AddressLink = ({ children, address, className, ariaLabel }) => (
+  <AddressLinkContainer
+    to={`/address/${address}`}
+    className={className}
+    aria-label={ariaLabel}
+  >
     {children}
   </AddressLinkContainer>
 )

--- a/src/components/Links/ContentHashLink.js
+++ b/src/components/Links/ContentHashLink.js
@@ -55,7 +55,11 @@ const ContentHashLink = ({ value, contentType, domain }) => {
     console.warn(`Unsupported protocol ${protocolType}`)
   }
   return (
-    <ContentHashLinkContainer target="_blank" href={externalLink}>
+    <ContentHashLinkContainer
+      target="_blank"
+      href={externalLink}
+      aria-label={contentType}
+    >
       {url}
       <ExternalLinkIcon />
     </ContentHashLinkContainer>

--- a/src/components/Links/RecordLink.js
+++ b/src/components/Links/RecordLink.js
@@ -90,7 +90,12 @@ const RecordLink = ({ textKey, value, name }) => {
 
   return url && !isEmpty ? (
     <LinkContainer>
-      <a target="_blank" href={url} rel="noopener noreferrer">
+      <a
+        target="_blank"
+        href={url}
+        rel="noopener noreferrer"
+        aria-label={textKey}
+      >
         {value}
         <img
           src={externalLinkSvg}
@@ -108,6 +113,7 @@ const RecordLink = ({ textKey, value, name }) => {
           target="_blank"
           href={host_meta?.reference_url}
           rel="noopener noreferrer"
+          aria-label={textKey}
         >
           {value}
           <img
@@ -127,7 +133,11 @@ const RecordLink = ({ textKey, value, name }) => {
         <NotSet>Not set</NotSet>
       ) : (
         <>
-          <UnlinkedValue data-testid={`unlinked-value-${textKey}`}>
+          <UnlinkedValue
+            data-testid={`unlinked-value-${textKey}`}
+            tabIndex={0}
+            aria-label={textKey}
+          >
             {value}
           </UnlinkedValue>
           <CopyToClipboard value={value} />

--- a/src/components/SingleName/DetailsContainer.js
+++ b/src/components/SingleName/DetailsContainer.js
@@ -235,7 +235,9 @@ function DetailsContainer({
         <DetailsItem uneditable>
           <DetailsKey>{t('c.parent')}</DetailsKey>
           <DetailsValue>
-            <Link to={`/name/${domainParent}`}>{domainParent}</Link>
+            <Link to={`/name/${domainParent}`} aria-label={t('c.parent')}>
+              {domainParent}
+            </Link>
           </DetailsValue>
         </DetailsItem>
       ) : (
@@ -295,7 +297,10 @@ function DetailsContainer({
             <DetailsItem uneditable>
               <DetailsKey>{t('c.registrant')}</DetailsKey>
               <DetailsValue>
-                <AddressLink address={domain.deedOwner}>
+                <AddressLink
+                  address={domain.deedOwner}
+                  arialLabel={t('c.registrant')}
+                >
                   <SingleNameBlockies
                     address={domain.deedOwner}
                     imageSize={24}
@@ -326,7 +331,7 @@ function DetailsContainer({
               {t('c.Controller')} {isOwner ? <You /> : ''}
             </DetailsKey>
             <DetailsValue>
-              <AddressLink address={domain.owner}>
+              <AddressLink address={domain.owner} ariaLabel={t('c.Controller')}>
                 {outOfSync ? (
                   <SingleNameBlockies
                     address={domain.owner}
@@ -409,7 +414,10 @@ function DetailsContainer({
                 {dnssecmode.displayError ? (
                   <DNSOwnerError>{dnssecmode.title}</DNSOwnerError>
                 ) : (
-                  <AddressLink address={domain.dnsOwner}>
+                  <AddressLink
+                    address={domain.dnsOwner}
+                    ariaLabel={t('dns.dnsowner')}
+                  >
                     <SingleNameBlockies
                       address={domain.dnsOwner}
                       imageSize={24}

--- a/src/components/SingleName/DetailsItemEditable.js
+++ b/src/components/SingleName/DetailsItemEditable.js
@@ -453,7 +453,7 @@ const Editable = ({
               expiryDate={type === 'date'}
             >
               {type === 'address' ? (
-                <AddressLink address={value}>
+                <AddressLink address={value} ariaLabel={t(`c.${keyName}`)}>
                   <SingleNameBlockies address={value} imageSize={24} />
                   {keyName === 'Resolver' &&
                   domain.contentType === 'oldcontent' ? (
@@ -481,7 +481,12 @@ const Editable = ({
                 </AddressLink>
               ) : type === 'date' ? (
                 <>
-                  <ExpiryDate>{formatDate(value)}</ExpiryDate>
+                  <ExpiryDate
+                    tabIndex={0}
+                    aria-label={`${t(`c.${keyName}`)}${formatDate(value)}`}
+                  >
+                    {formatDate(value)}
+                  </ExpiryDate>
                   <AddToCalendar
                     css={css`
                       margin-right: 20px;
@@ -714,7 +719,7 @@ function ViewOnly({
         <DetailsKey>{t(`c.${keyName}`)}</DetailsKey>
         <DetailsValue data-testid={`details-value-${keyName.toLowerCase()}`}>
           {type === 'address' ? (
-            <AddressLink address={value}>
+            <AddressLink address={value} ariaLabel={t(`c.${keyName}`)}>
               <SingleNameBlockies address={value} imageSize={24} />
               {value}
             </AddressLink>

--- a/src/components/SingleName/NameRegister/Years.js
+++ b/src/components/SingleName/NameRegister/Years.js
@@ -88,6 +88,7 @@ const Years = ({ years, setYears }) => {
           <input
             type="text"
             value={years}
+            aria-label={t('pricer.yearUnit')}
             onChange={e => {
               const sign = Math.sign(e.target.value)
               if (sign === -1 || isNaN(sign)) {

--- a/src/components/SingleName/ResolverAndRecords/RecordsItem.js
+++ b/src/components/SingleName/ResolverAndRecords/RecordsItem.js
@@ -239,7 +239,9 @@ const RecordItemEditable = ({
           <RecordsKey>{t(`c.${keyName}`)}</RecordsKey>
           <RecordsValue editableSmall>
             {type === 'address' ? (
-              <AddressLink address={value}>{value}</AddressLink>
+              <AddressLink address={value} ariaLabel={t(`c.${keyName}`)}>
+                {value}
+              </AddressLink>
             ) : (
               <ContentHashLink
                 value={value}
@@ -426,7 +428,9 @@ function RecordItemViewOnly({ keyName, value, type, domain }) {
         <RecordsKey>{t(`c.${keyName}`)}</RecordsKey>
         <RecordsValue>
           {type === 'address' ? (
-            <AddressLink address={value}>{value}</AddressLink>
+            <AddressLink address={value} ariaLabel={t(`c.${keyName}`)}>
+              {value}
+            </AddressLink>
           ) : (
             <ContentHashLink
               value={value}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue number
#1368

<!--- If there is an associated github issues, please specify here -->

## Description

<!--- Describe your changes in detail -->
This PR adds aria labels to anchor and input elements which can be read aloud by a screen reader.
## List of features added/changed

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- record's type in the ENS name's content record
- domain's details (parent, registrant, controller, expiration date and resolver)
- registration period input

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Tested with the Orca screen reader from the GNOME project (version 3.36.2).

## Screenshots (if appropriate):
N/A
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My code implements all the required features.
