### PR TITLE
Trim whitespace

### DIFF
--- a/src/components/SingleName/DetailsItemEditable.js
+++ b/src/components/SingleName/DetailsItemEditable.js
@@ -292,7 +292,7 @@ function getInputType(
   return (
     <Input
       value={newValue}
-      onChange={e => updateValue(e.target.value)}
+      onChange={e => updateValue(e.target.value.trim())}
       valid={isValid}
       invalid={isInvalid}
       placeholder={keyName === 'Resolver' ? placeholder : ''}

--- a/src/components/SingleName/DetailsItemInput.js
+++ b/src/components/SingleName/DetailsItemInput.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import styled from '@emotion/styled/macro'
-import { getPlaceholder } from '../../utils/records'
+import { getPlaceholder, trimRecord } from '../../utils/records'
 import DefaultInput from '../Forms/Input'
 
 const Input = styled(DefaultInput)`
@@ -23,7 +23,7 @@ const DetailsItemInput = ({
       invalid={isInvalid}
       placeholder={placeholder || getPlaceholder(dataType, contentType)}
       onChange={e => {
-        updateValue(e.target.value)
+        updateValue(trimRecord(contentType, e.target.value))
       }}
       value={newValue}
     />

--- a/src/components/SingleName/ResolverAndRecords/AddRecord.js
+++ b/src/components/SingleName/ResolverAndRecords/AddRecord.js
@@ -242,6 +242,7 @@ function Editable({
               <DetailsItemInput
                 newValue={newValue || ''}
                 dataType={selectedRecord ? selectedRecord.value : null}
+                contentType={selectedKey?.label}
                 updateValue={updateValue}
                 isValid
                 isInvalid={!isValid}

--- a/src/components/SingleName/ResolverAndRecords/ContentHash.js
+++ b/src/components/SingleName/ResolverAndRecords/ContentHash.js
@@ -199,7 +199,10 @@ const ContentHashEditable = ({
                 <RecordInput
                   testId={`content-record-input${isInvalid ? '-invalid' : ''}`}
                   onChange={event => {
-                    updateRecord({ ...record, value: event.target.value })
+                    updateRecord({
+                      ...record,
+                      value: event.target.value.trim()
+                    })
                   }}
                   hasBeenUpdated={hasChange(changedRecords, keyName)}
                   value={value}

--- a/src/components/SingleName/ResolverAndRecords/KeyValueRecord/KeyValueRecord.js
+++ b/src/components/SingleName/ResolverAndRecords/KeyValueRecord/KeyValueRecord.js
@@ -12,6 +12,7 @@ import {
 import RecordInput from '../../RecordInput'
 import DefaultBin from '../../../Forms/Bin'
 import { emptyAddress } from '../../../../utils/utils'
+import { trimRecord } from '../../../../utils/records'
 
 const Bin = styled(DefaultBin)`
   align-self: center;
@@ -115,7 +116,10 @@ const Editable = ({
             type="text"
             isInvalid={!isValid}
             onChange={event => {
-              updateRecord({ ...record, value: event.target.value })
+              updateRecord({
+                ...record,
+                value: trimRecord(key, event.target.value)
+              })
             }}
             value={value === emptyAddress ? '' : value}
             {...{ placeholder, isValid }}

--- a/src/utils/records.js
+++ b/src/utils/records.js
@@ -46,6 +46,20 @@ export function getPlaceholder(recordType, contentType) {
   }
 }
 
+export const trimRecord = (key, value) => {
+  const untrimmedRecordTypes = [
+    'description',
+    'notice',
+    'keywords',
+    'name',
+    'location'
+  ]
+  if (untrimmedRecordTypes.every(type => type !== key)) {
+    return value.trim()
+  }
+  return value
+}
+
 export const EMPTY_ADDRESS = '0x0000000000000000000000000000000000000000'
 
 export function isEmptyAddress(address) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue number

<!--- If there is an associated github issues, please specify here -->
#1382

## Description

<!--- Describe your changes in detail -->
Upon pasting an address in the Resolver field or a record entry with leading or trailing spaces, it displays a malformed error. This PR trims off any leading or trailing whitespace unless the record type is a description, notice, keywords, name or location.

## List of features added/changed

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] trim functionality on change event for any record type except description, notice, keywords, name and location
- [x] trim functionality on change event for the Resolver field

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
I have appended and prepended whitespace to the input and then pasted it to see if the malformed warning showed up. All unit tests pass:
![image](https://user-images.githubusercontent.com/53792888/145123415-e0642964-ecb3-401d-ad57-76e55a899270.png)

## Screenshots (if appropriate):
N/A
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My code implements all the required features.
