### PR TITLE
Set autoCapitalize="off" on search field

### DIFF
--- a/src/components/SearchName/Search.js
+++ b/src/components/SearchName/Search.js
@@ -130,6 +130,7 @@ function Search({ history, className, style }) {
         placeholder={t('search.placeholder')}
         ref={el => (input = el)}
         onChange={handleParse}
+        autoCapitalize="off"
       />
       <LanguageSwitcher />
       <button


### PR DESCRIPTION
Fixes #1271 

## Description
Set autocapitalize="off" on the search field so that it doesn't capitalize

## List of features added/changed

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->


## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My code implements all the required features.
