### PR TITLE
Hooks invoke conditionally in Favourites component

### DIFF
--- a/src/routes/Favourites.js
+++ b/src/routes/Favourites.js
@@ -123,6 +123,7 @@ function Favourites() {
   let [years, setYears] = useState(1)
   let [checkedBoxes, setCheckedBoxes] = useState({})
   const [selectAll, setSelectAll] = useState(false)
+  const account = useAccount()
 
   useResetState(setYears, setCheckedBoxes, setSelectAll)
 
@@ -208,7 +209,6 @@ function Favourites() {
     setCheckedBoxes(obj)
   }
   let data = []
-  const account = useAccount()
   const checkedOtherOwner =
     favouritesList.filter(
       f =>

--- a/src/routes/Favourites.js
+++ b/src/routes/Favourites.js
@@ -268,6 +268,7 @@ function Favourites() {
               checkedBoxes={checkedBoxes}
               setCheckedBoxes={setCheckedBoxes}
               setSelectAll={setSelectAll}
+              key={domain.name}
             />
           )
         })}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue number
#1386

<!--- If there is an associated github issues, please specify here -->

## Description

<!--- Describe your changes in detail -->
After the last domain is deleted form the list of favourites (`favourites` constant is then an empty array), `NoDomains` component is returned and `useAccount` custom hook is therefore no longer invoked which throws an error. Hooks should be called in the same order each time a component renders and not invoked conditionally. This PR moves the `useAccount` hook up to the top level of the Favourites component so that it gets called regardless of whether the list of favourites is empty or not.
## List of features added/changed

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Hooks are now called in the same order each time the component renders 
- [x] Add `key` attribute that uniquely identifies a domain inside the `favouritesList` array 

## How Has This Been Tested?
No longer throws an error when clicking on the heart icon of the last domain in the list and all existing unit tests pass:
![image](https://user-images.githubusercontent.com/53792888/145894033-d2147c07-9e46-4f56-92fc-f9f7f00cd393.png)

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
N/A

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My code implements all the required features.
