### PR TITLE
Call setup again if network changes

### DIFF
--- a/src/setup.js
+++ b/src/setup.js
@@ -134,6 +134,13 @@ export const setWeb3Provider = async provider => {
       })
       return
     }
+
+    await setup({
+      customProvider: provider,
+      reloadOnAccountsChange: false,
+      enforceReload: true
+    })
+
     networkIdReactive(networkId)
     networkReactive(await getNetwork())
   })


### PR DESCRIPTION
## Issue number

#1402 

## Description

We need to call setup again if the network changes so that the correct contract addresses can be recalculated

## How Has This Been Tested?

Load the app with goerli initially, change to mainnet, renew a name and check the destination address of the transaction

## Checklist:

- [x] My code follows the code style of this project.
- [x] My code implements all the required features.
