### PR TITLE
Reset isValid and isValidating on save (#1408)

### DIFF
--- a/src/components/SingleName/ResolverAndRecords/AddRecord.js
+++ b/src/components/SingleName/ResolverAndRecords/AddRecord.js
@@ -312,6 +312,8 @@ function Editable({
                   contractFn: selectedRecord?.contractFn
                 })
                 clearInput(setSelectedRecord, setSelectedKey, updateValue)
+                setIsValid(false)
+                setIsValidating(false)
               }}
             >
               Save


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue number

<!--- If there is an associated github issues, please specify here -->
#1408
## Description

<!--- Describe your changes in detail -->
After setting a record and clicking on the Save button, the button remains clickable. This PR sets the state of `isValid` and `isValidating` to `false` so that the button is disabled.
## List of features added/changed

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- `isValid` and `isValidating` states are set to `false` when clicking on save to add a record

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Run changes against existing unit tests:
![image](https://user-images.githubusercontent.com/53792888/147000346-db8152e4-f40d-4c62-8925-007e5d120a96.png)

## Screenshots (if appropriate):
N/A
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My code implements all the required features.
