### PR TITLE
Fix subdomain deletion unknown preimage

### DIFF
--- a/src/api/labels.js
+++ b/src/api/labels.js
@@ -1,5 +1,9 @@
 import jsSHA3 from 'js-sha3'
-import { isEncodedLabelhash, decodeLabelhash } from '@ensdomains/ui'
+import {
+  isEncodedLabelhash,
+  decodeLabelhash,
+  encodeLabelhash
+} from '@ensdomains/ui'
 
 function getLabels() {
   return JSON.parse(localStorage.getItem('labels')) || {}
@@ -41,6 +45,18 @@ export function checkLabel(hash) {
 
   if (hash.startsWith('0x')) {
     return labels[`${hash.slice(2)}`]
+  }
+}
+
+export function encodeLabel(name) {
+  try {
+    const nameArray = name.split('.')
+    const label = nameArray[0]
+    const node = nameArray.slice(1).join('.')
+    const labelhash = encodeLabelhash(label)
+    return `${labelhash}.${node}`
+  } catch {
+    return name
   }
 }
 

--- a/src/api/labels.js
+++ b/src/api/labels.js
@@ -37,6 +37,11 @@ export function saveName(name) {
   })
 }
 
+export function parseName(name) {
+  const nameArray = name.split('.')
+  return nameArray.map(label => encodeLabel(label)).join('.')
+}
+
 export function checkLabel(hash) {
   const labels = getLabels()
   if (isEncodedLabelhash(hash)) {
@@ -48,15 +53,11 @@ export function checkLabel(hash) {
   }
 }
 
-export function encodeLabel(name) {
+export function encodeLabel(label) {
   try {
-    const nameArray = name.split('.')
-    const label = nameArray[0]
-    const node = nameArray.slice(1).join('.')
-    const labelhash = encodeLabelhash(label)
-    return `${labelhash}.${node}`
+    return encodeLabelhash(label)
   } catch {
-    return name
+    return label
   }
 }
 

--- a/src/api/labels.test.js
+++ b/src/api/labels.test.js
@@ -1,4 +1,10 @@
-import { checkLabel, saveLabel, saveName } from './labels'
+import {
+  checkLabel,
+  saveLabel,
+  saveName,
+  parseName,
+  encodeLabel
+} from './labels'
 const KEY = 'labels'
 
 const blahblahHash =
@@ -74,5 +80,35 @@ describe('saveName', () => {
       [hashes[1]]: nameArray[1],
       [hashes[2]]: nameArray[2]
     })
+  })
+})
+
+describe('encodeLabel', () => {
+  it('should return the encoded labelhash if the label is a 32 bytes hexadecimal string', () => {
+    const hash = '0x' + blahblahHash
+    const encodedLabelHash = `[${blahblahHash}]`
+    const label = encodeLabel(hash)
+    expect(label).toEqual(encodedLabelHash)
+  })
+
+  it('should return the label if the label is not a 32 bytes hexadecimal string', () => {
+    const label = 'awesome'
+    const parsedLabel = encodeLabel(label)
+    expect(parsedLabel).toEqual(label)
+  })
+})
+
+describe('parseName', () => {
+  it('should parse all the labels (2) and return the encoded string', () => {
+    const name = 'vitalik.eth'
+    const parsedName = parseName(name)
+    expect(parsedName).toEqual(name)
+  })
+
+  it('should parse all the labels (3) and return the encoded string', () => {
+    const name = `0x${blahblahHash}.vitalik.eth`
+    const encodedName = `[${blahblahHash}].vitalik.eth`
+    const parsedName = parseName(name)
+    expect(parsedName).toEqual(encodedName)
   })
 })

--- a/src/components/DomainItem/ChildDomainItem.js
+++ b/src/components/DomainItem/ChildDomainItem.js
@@ -8,7 +8,11 @@ import Checkbox from '../Forms/Checkbox'
 import mq, { useMediaMin } from 'mediaQuery'
 import Tooltip from '../Tooltip/Tooltip'
 import QuestionMark from '../Icons/QuestionMark'
-import { checkIsDecrypted, truncateUndecryptedName } from '../../api/labels'
+import {
+  checkIsDecrypted,
+  truncateUndecryptedName,
+  encodeLabel
+} from '../../api/labels'
 import ExpiryDate from './ExpiryDate'
 import { useMutation } from '@apollo/client'
 import Bin from '../Forms/Bin'
@@ -94,7 +98,7 @@ export default function ChildDomainItem({
       }
     },
     variables: {
-      name: name
+      name: encodeLabel(name)
     }
   })
 

--- a/src/components/DomainItem/ChildDomainItem.js
+++ b/src/components/DomainItem/ChildDomainItem.js
@@ -11,7 +11,7 @@ import QuestionMark from '../Icons/QuestionMark'
 import {
   checkIsDecrypted,
   truncateUndecryptedName,
-  encodeLabel
+  parseName
 } from '../../api/labels'
 import ExpiryDate from './ExpiryDate'
 import { useMutation } from '@apollo/client'
@@ -98,7 +98,7 @@ export default function ChildDomainItem({
       }
     },
     variables: {
-      name: encodeLabel(name)
+      name: parseName(name)
     }
   })
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue number

<!--- If there is an associated github issues, please specify here -->
#1400
## Description

<!--- Describe your changes in detail -->
As per issue, if the preimage / subdomain name is not known, the 0x labelhash shows instead on the subdomains page of the ens manager app. When deleting such subdomain without known preimage, the labelhash is hashed a second time before being included as argument in the `setSubnodeRecord` method of the ENS registry. This PR checks whether the label is a 32 bytes hexadecimal string or not and if yes, the label is encoded (i.e. removes "0x" prefix and wrapped in brackets) so that the labelhash is not hashed a second time in the `labehash` function before sending the transaction to the network.   
## List of features added/changed

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] `encodeLabel` utility function that parses the label and return the encoded label if the label is a 32 bytes hex string or the unmodified label if not
- [x] `parseName` function that applies the `encodeLabel` function to all labels

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Added unit tests for `encodeLabel` and `parseName` functions
![image](https://user-images.githubusercontent.com/53792888/147135966-751da46c-dfc7-43ed-8040-a57fd2a7fac9.png)

## Screenshots (if appropriate):
N/A
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My code implements all the required features.
