### PR TITLE
Fix DAO Banner height on mobile

### DIFF
--- a/src/components/Banner/DAOBanner.js
+++ b/src/components/Banner/DAOBanner.js
@@ -25,7 +25,6 @@ const Link = styled(`a`)`
 `
 
 const ArrowSmall = styled(motion.img)`
-  height: 100%;
   margin: auto;
   display: block;
   width: 22px;


### PR DESCRIPTION
## Issue number
Fixes #1413 

## Description
By removing the `height: 100%;` from the ArrowSmall styling, the image no longer takes up unnecessary space. 
100% height was not needed for this component.

## List of features added/changed
- [x] Improved DAO Banner height on mobile screens.

## How Has This Been Tested?

- Verified that the height of the banner looks good on **Mobile** by using Safari's Responsive Design Mode to emulate different mobile screen sizes.
- Verified that the height of the banner looks the same as before on **Desktop** in Chrome, Safari, Brave, and FireFox. 

## Screenshots:
![image](https://user-images.githubusercontent.com/29494270/147403551-63b7554c-f5f9-434c-9349-dc26cc7969a3.png)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My code implements all the required features.
