### PR TITLE
fix: unexpected plus behavior on the Registration Period Input

### DIFF
--- a/src/components/SingleName/NameRegister/Years.js
+++ b/src/components/SingleName/NameRegister/Years.js
@@ -94,7 +94,7 @@ const Years = ({ years, setYears }) => {
               if (sign === -1 || isNaN(sign)) {
                 setYears(0)
               } else {
-                setYears(e.target.value)
+                setYears(Number(e.target.value))
               }
             }}
           />{' '}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Issue number

https://github.com/ensdomains/ens-app/issues/1421

## Description

Describe the bug
See the reproduce below. I add some screenshots

To Reproduce
Steps to reproduce the behavior:

1. Go to 'https://app.ens.domains/name/aaabbbccc.eth/register', an unregister domain
2. Input a numer greater then 1 year, for example 5 years
3. Click then '+' button right the input, expect '6' , but '51' display.
4. See error

Expected behavior
When people click '+' button, we expect the number N+1, not the string plus 'N1'.

## List of features added/changed

no feature

## How Has This Been Tested?

Tested. online demo see at https://ens-app-ten.vercel.app/name/statexxx.eth/register

## Screenshots (if appropriate):
when I input '5'
![image](https://user-images.githubusercontent.com/7405300/149730461-3a3e03fc-80a1-4416-8a6d-fd7c4bfffd7b.png)

when I clicked the '+' icon
![image](https://user-images.githubusercontent.com/7405300/149730501-5251afe2-28c1-444b-a257-d40bf88e85df.png)



## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My code implements all the required features.
