### PR TITLE
Make tooltip visible for exponential premium chart

### DIFF
--- a/src/components/SingleName/NameRegister/LineGraph.js
+++ b/src/components/SingleName/NameRegister/LineGraph.js
@@ -110,8 +110,7 @@ export default function LineGraph({
   }
   useEffect(() => {
     const ctx = chartRef.current.getContext('2d')
-    Chart.defaults.global.tooltips.yAlign = 'top'
-    Chart.defaults.global.tooltips.xAlign = 'center'
+    Chart.defaults.global.tooltips.yAlign = 'bottom'
     let _chart = new Chart(ctx, {
       type: 'line',
       data: {
@@ -189,7 +188,7 @@ export default function LineGraph({
           ],
           yAxes: [
             {
-              ticks: { display: false, max: chartstartPremium * 1.1 },
+              ticks: { display: false, max: chartstartPremium * 1.5 },
               gridLines: {
                 display: false,
                 drawBorder: false
@@ -198,7 +197,7 @@ export default function LineGraph({
           ]
         },
         layout: {
-          padding: {}
+          padding: { bottom: 5, top: 5 }
         }
       }
     })


### PR DESCRIPTION
- Chang tooltip display position
- Add padding 

<img width="476" alt="Screenshot 2022-05-09 at 17 57 11" src="https://user-images.githubusercontent.com/2630/167461039-13ece8dc-380d-41cc-b0bc-958952184c73.png">


<img width="352" alt="Screenshot 2022-05-09 at 17 57 22" src="https://user-images.githubusercontent.com/2630/167461019-8cbf276b-be77-4dca-83ba-d77841cf1799.png">

NOTE: I have problem automatically changing tooltip position so it may not necessarily show the tooltip well on mobile on top left.

<img width="343" alt="Screenshot 2022-05-09 at 18 07 51" src="https://user-images.githubusercontent.com/2630/167461450-836b6bec-fd63-4172-8cb7-e249d173bd39.png">

