### PR TITLE
feat: EPNS optin integration

### DIFF
--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -382,5 +382,18 @@
       "title": "ENS constitution book now available",
       "description": "A printed copy of the ENS constitution and its signers is now available in hardcover and ultra-limited edition of 50"
     }
+  },
+  "epns": {
+    "link": "Wallet Notif (EPNS)",
+    "modal": {
+      "header": "You can choose to Opt-In/Opt-Out EPNS Notifications from ENS!",
+      "optInButton": "OPT-IN",
+      "optOutButton": "OPT-OUT",
+      "platforms": "View Supported Platforms",
+      "alreadyOpted": "You are Opted-In!",
+      "apiError": "Mayday! Mayday! Can the devs do something? They have been notified, please try again a little later!",
+      "unsupportedNetwork": "Wallet notifications are only supported on the Main net!",
+      "switchNetwork": "Switch Network"
+    }
   }
 }

--- a/src/components/Calendar/Dropdown.js
+++ b/src/components/Calendar/Dropdown.js
@@ -24,7 +24,7 @@ function Dropdown(props, ref) {
   const allChildren = prependChildren.concat(children).concat(appendChildren)
 
   return (
-    <div ref={ref} className={dropdownStyles}>
+    <div ref={ref} className={dropdownStyles} style={props.style}>
       {allChildren}
     </div>
   )

--- a/src/components/EPNS/EPNSLink.js
+++ b/src/components/EPNS/EPNSLink.js
@@ -1,0 +1,21 @@
+import React from 'react'
+
+const EPNSLink = ({ children, onClick = null }) => {
+  async function handleClick(e) {
+    e.preventDefault()
+
+    if (onClick) {
+      onClick(e)
+    }
+  }
+
+  return (
+    <>
+      <a href="#" onClick={handleClick}>
+        {children}
+      </a>
+    </>
+  )
+}
+
+export default EPNSLink

--- a/src/components/EPNS/EPNSNotificationModal.js
+++ b/src/components/EPNS/EPNSNotificationModal.js
@@ -1,0 +1,227 @@
+import styled from '@emotion/styled'
+import React, { useEffect, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+
+import {
+  default as Button,
+  getButtonDefaultStyles,
+  getButtonStyles
+} from '../Forms/Button'
+import Loader from '../Loader'
+import { useWeb3Data } from './useWeb3'
+import { selectConfig, isUserSubscribed, optIn, optOut } from './EPNSUtil'
+import OnSubscribedModal from './EPNSOnSubscribeModal'
+import NetworkSwitch from './SwitchNetwork'
+
+const LoadingComponent = styled(Loader)`
+  display: inline-block;
+  margin: 0 10px;
+  vertical-align: middle;
+`
+
+const FormComponent = styled('form')`
+  display: grid;
+  grid-gap: 10px;
+  font-weight: 200;
+`
+
+const FormLabel = styled('label')`
+  display: block;
+  margin-top: 20px;
+`
+
+const FormWarning = styled('div')`
+  color: #f5a623;
+  margin-bottom: 10px;
+`
+
+const FormError = styled(FormLabel)`
+  color: red;
+  font-size: 0.8rem;
+`
+
+const Header = styled('h3')`
+  font-size: 1rem;
+  font-weight: 400;
+  margin-top: 0;
+`
+
+const Row = styled('div')`
+  padding: 10px 0 30px;
+`
+
+const MessageBlock = styled('div')`
+  display: flex;
+  flex-direction: column;
+  margin-top: 30px;
+`
+const Actions = styled('div')`
+  display: flex;
+  justify-content: right;
+`
+
+const buttonStyles = `
+  margin: 5px;
+  position: relative;
+`
+
+const CancelComponent = styled(Button)`
+  ${getButtonDefaultStyles()}
+  ${getButtonStyles({ type: 'hollow' })}
+  ${buttonStyles}
+ `
+
+const EPNSNotificationModal = ({ address, onCancel }) => {
+  const { t } = useTranslation()
+
+  const { signer, networkId } = useWeb3Data()
+  const [epnsConfig, setEpnsConfig] = useState({})
+  const [isChannelSubscribed, setIsChannelSubscribed] = useState()
+  const [isLoading, setIsLoading] = useState()
+  const [isError, setError] = useState()
+  const [networkSupported, setNetworkSupported] = useState() // epns api don't support ropsten
+  const [isModalOpen, setIsModalOpen] = useState()
+
+  const isWeb3Ready = signer && address && networkId
+  const disableButton = !networkSupported || isError
+  const buttonType = disableButton ? 'disabled' : 'primary'
+
+  const handleSubmit = e => {
+    e.preventDefault()
+  }
+
+  async function callOptIn() {
+    setIsLoading(true)
+
+    await optIn(signer, epnsConfig.CHANNEL_ADDRESS, networkId, address, {
+      baseApiUrl: epnsConfig.API_BASE_URL,
+      onSuccess: () => {
+        setIsChannelSubscribed(true)
+        setIsLoading(false)
+        setIsModalOpen(true)
+      },
+      onError: err => {
+        setError(true)
+        setIsLoading(false)
+      }
+    })
+  }
+
+  async function callOptOut() {
+    setIsLoading(true)
+
+    await optOut(signer, epnsConfig.CHANNEL_ADDRESS, networkId, address, {
+      baseApiUrl: epnsConfig.API_BASE_URL,
+      onSuccess: () => {
+        setIsChannelSubscribed(false)
+        setIsLoading(false)
+      },
+      onError: err => {
+        setError(true)
+        setIsLoading(false)
+      }
+    })
+  }
+
+  const toggleSubscription = () => {
+    if (!isChannelSubscribed) {
+      callOptIn()
+    } else {
+      callOptOut()
+    }
+  }
+
+  const toggleModal = () => {
+    setIsModalOpen(value => !value)
+  }
+
+  async function fetchAndUpdateSubscription() {
+    try {
+      setIsLoading(true)
+      const status = await isUserSubscribed(
+        address,
+        epnsConfig.CHANNEL_ADDRESS,
+        epnsConfig.API_BASE_URL
+      )
+      setIsChannelSubscribed(status)
+    } catch (err) {
+      setError(true)
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    // determine the config
+    if (networkId) {
+      setEpnsConfig(selectConfig(networkId))
+    }
+  }, [networkId])
+
+  useEffect(() => {
+    // fetch the channel details if we have config
+    const isSupprtedNW = Object.keys(epnsConfig).length > 0
+    if (isSupprtedNW) {
+      fetchAndUpdateSubscription()
+    }
+
+    setNetworkSupported(isSupprtedNW)
+  }, [epnsConfig])
+
+  return (
+    <FormComponent onSubmit={handleSubmit}>
+      <FormLabel htmlFor="epns">
+        <Header>{t('epns.modal.header')}</Header>
+      </FormLabel>
+
+      <Row>
+        <Button type="hollow-primary" onClick={toggleModal}>
+          {t('epns.modal.platforms')}
+        </Button>
+      </Row>
+
+      {isWeb3Ready ? (
+        <Row>
+          {isLoading ? (
+            <LoadingComponent />
+          ) : isChannelSubscribed ? (
+            <Button
+              onClick={toggleSubscription}
+              type={buttonType}
+              disabled={disableButton}
+            >
+              {t('epns.modal.optOutButton')}
+            </Button>
+          ) : (
+            <Button
+              onClick={toggleSubscription}
+              type={buttonType}
+              disabled={disableButton}
+            >
+              {t('epns.modal.optInButton')}
+            </Button>
+          )}
+
+          {!networkSupported ? (
+            <MessageBlock>
+              <FormWarning>{t('epns.modal.unsupportedNetwork')}</FormWarning>
+              <NetworkSwitch>{t('epns.modal.switchNetwork')}</NetworkSwitch>
+            </MessageBlock>
+          ) : null}
+          {isError ? <FormError> {t('epns.modal.apiError')}</FormError> : null}
+        </Row>
+      ) : (
+        <LoadingComponent />
+      )}
+
+      <Actions>
+        <CancelComponent onClick={onCancel}>{t('c.cancel')}</CancelComponent>
+      </Actions>
+
+      {/* OnSubscribeModal */}
+      {isModalOpen ? <OnSubscribedModal onClose={toggleModal} /> : null}
+    </FormComponent>
+  )
+}
+
+export default EPNSNotificationModal

--- a/src/components/EPNS/EPNSOnSubscribeModal.js
+++ b/src/components/EPNS/EPNSOnSubscribeModal.js
@@ -1,0 +1,176 @@
+import React from 'react'
+// import * as ReactUse from "react-use";
+import styled from '@emotion/styled'
+import { LINKS, CLOSE_ICON } from './EPNSUtil'
+import { useOnClickOutside } from 'components/hooks'
+
+const OnSubscribedModal = ({ onClose }) => {
+  const modalRef = React.useRef(null)
+  // dummy function to help navigate to another page
+  const goto = url => {
+    window.open(url, '_blank')
+  }
+
+  //  ReactUse.useClickAway(modalRef, onClose);
+  useOnClickOutside([modalRef], () => onClose())
+
+  return (
+    <Overlay className="overlay">
+      <Modal className="modal" ref={modalRef}>
+        <img onClick={onClose} src={CLOSE_ICON} alt="" />
+        <Item className="modal__heading">
+          <CustomHeaderTwo>
+            <CustomSpan style={{ marginRight: '10px' }}>Recieve</CustomSpan>
+            <StyledSpan>Notifications</StyledSpan>
+          </CustomHeaderTwo>
+          <H3>
+            Recieve notifications from <b>EPNS</b> via the following platforms.
+          </H3>
+        </Item>
+
+        <Item className="modal__content">
+          {LINKS.map((oneLink, idx) => (
+            <ItemLink onClick={() => goto(oneLink.link)} key={idx}>
+              <img src={oneLink.img} alt="" />
+              {oneLink.text}
+            </ItemLink>
+          ))}
+        </Item>
+      </Modal>
+    </Overlay>
+  )
+}
+
+const ItemLink = styled.div`
+  width: 260px;
+  height: 62px;
+  padding-left: 22px;
+
+  background: #fafafa;
+  border: 0.2px solid rgba(0, 0, 0, 0.16);
+  box-sizing: border-box;
+  border-radius: 5px;
+  font-size: 0.75em;
+  text-transform: uppercase;
+  display: flex;
+  align-items: center;
+  gap: 1.3125em;
+
+  cursor: pointer;
+  transition: 300ms;
+
+  &:hover {
+    box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
+  }
+`
+const CustomHeaderTwo = styled.h2`
+  margin-top: 0;
+  margin-bottom: 1em;
+  color: rgb(0, 0, 0);
+  font-weight: 600;
+  font-size: 1.5625em;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  padding: 0px;
+  font-family: inherit;
+  text-align: inherit;
+`
+
+const Item = styled.div`
+  display: flex;
+  flex-direction: column;
+  text-transform: capitalise;
+
+  &.modal__heading {
+    margin-bottom: 3.3125rem;
+  }
+
+  &.modal__content {
+    display: grid;
+    grid-template-columns: 50% 50%;
+    grid-row-gap: 3.3125em;
+  }
+`
+
+const CustomSpan = styled.span`
+  flex: initial;
+  align-self: auto;
+  color: rgb(0, 0, 0);
+  background: transparent;
+  font-weight: 400;
+  font-size: inherit;
+  text-transform: inherit;
+  margin: 0px;
+  padding: 0px;
+  letter-spacing: inherit;
+  text-align: initial;
+  position: initial;
+  inset: auto;
+  z-index: auto;
+`
+
+const StyledSpan = styled(CustomSpan)`
+  background: rgb(226, 8, 128);
+  color: #fff;
+  font-weight: 600;
+  padding: 3px 8px;
+`
+
+const H3 = styled.h3`
+  color: rgb(0 0 0 / 0.5);
+  font-weight: 300;
+  font-size: 1em;
+  text-transform: uppercase;
+  margin: -15px 0px 20px 0px;
+  padding: 0px;
+  letter-spacing: 0.1em;
+  font-family: 'Source Sans Pro', Helvetica, sans-serif;
+  text-align: inherit;
+  max-width: initial;
+`
+
+const Overlay = styled.div`
+  top: 0;
+  left: 0;
+  right: 0;
+  background: rgba(0, 0, 0, 0.85);
+  height: 100%;
+  width: 100%;
+  z-index: 1000;
+  position: fixed;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  overflow-y: scroll;
+`
+
+const Modal = styled.div`
+  padding: 3.875em;
+  background: white;
+  text-align: left;
+  border: 1px solid rgba(0, 0, 0, 0.16);
+  box-sizing: border-box;
+  box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
+  border-radius: 15px;
+  position: relative;
+
+  & > img {
+    position: absolute;
+    right: 40px;
+    top: 40px;
+    cursor: pointer;
+  }
+
+  @media (max-width: 1000px) {
+    width: max(70vw, 350px);
+    padding: 2em;
+    .modal__content {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 20px;
+    }
+  }
+`
+
+export default OnSubscribedModal

--- a/src/components/EPNS/EPNSUtil.js
+++ b/src/components/EPNS/EPNSUtil.js
@@ -1,0 +1,242 @@
+const EPNS_CONFIG = {
+  // MAIN_NET - prod
+  1: {
+    CHANNEL_ADDRESS: '0x983110309620D911731Ac0932219af06091b6744', // ENS address
+    API_BASE_URL: 'https://backend-prod.epns.io/apis',
+    EPNS_COMMUNICATOR_CONTRACT: '0xb3971BCef2D791bc4027BbfedFb47319A4AAaaAa'
+  }
+}
+
+const signingConstants = {
+  // The several types of actions and their corresponding types
+  //  which we can take, when it comes to signing messages
+  ACTION_TYPES: {
+    // the type to be used for the subscribe action to a channel
+    subscribe: {
+      Subscribe: [
+        { name: 'channel', type: 'address' },
+        { name: 'subscriber', type: 'address' },
+        { name: 'action', type: 'string' }
+      ]
+    },
+    // the type to be used for the unsubscribe action to a channel
+    unsubscribe: {
+      Unsubscribe: [
+        { name: 'channel', type: 'address' },
+        { name: 'unsubscriber', type: 'address' },
+        { name: 'action', type: 'string' }
+      ]
+    }
+  }
+}
+
+function getDomainInformation(chainId, verifyingContractAddress) {
+  return {
+    name: 'EPNS COMM V1',
+    chainId: chainId,
+    verifyingContract:
+      verifyingContractAddress ||
+      EPNS_CONFIG[chainId].EPNS_COMMUNICATOR_CONTRACT
+  }
+}
+
+function getSubscriptionMessage(channelAddress, userAddress, action) {
+  return {
+    channel: channelAddress,
+    [action === 'Unsubscribe' ? 'unsubscriber' : 'subscriber']: userAddress,
+    action: action
+  }
+}
+
+async function fetchPOST(url, body = {}, options = {}) {
+  return fetch(url, {
+    method: 'POST',
+    headers: {
+      'Content-type': 'application/json; charset=UTF-8'
+    },
+    ...options,
+    body: body
+  })
+    .then(async response => {
+      const isJson = response.headers
+        .get('content-type')
+        ?.includes('application/json')
+      const data = isJson ? await response.json() : null
+
+      // check for error response
+      if (!response.ok) {
+        // get error message from body or default to response status
+        const error = (data && data.message) || response.status
+        return Promise.reject(error)
+      }
+
+      return Promise.resolve(data)
+    })
+    .catch(error => {
+      console.error('EPNS API Fetch error: ', error)
+      throw error
+    })
+}
+
+async function optIn(
+  signer,
+  channelAddress,
+  chainId,
+  userAddress,
+  {
+    baseApiUrl = EPNS_CONFIG[chainId].API_BASE_URL,
+    verifyingContractAddress = EPNS_CONFIG[chainId].EPNS_COMMUNICATOR_CONTRACT,
+    onSuccess = () => 'success',
+    onError = () => 'error'
+  } = {}
+) {
+  try {
+    // get domain information
+    const domainInformation = getDomainInformation(
+      chainId,
+      verifyingContractAddress
+    )
+    // get type information
+    const typeInformation = signingConstants.ACTION_TYPES['subscribe']
+    // get message
+    const messageInformation = getSubscriptionMessage(
+      channelAddress,
+      userAddress,
+      'Subscribe'
+    )
+    // sign message
+    const signature = await signer._signTypedData(
+      domainInformation,
+      typeInformation,
+      messageInformation
+    )
+
+    const postBody = JSON.stringify({
+      signature,
+      message: messageInformation,
+      op: 'write',
+      chainId,
+      contractAddress: verifyingContractAddress
+    })
+
+    await fetchPOST(`${baseApiUrl}/channels/subscribe_offchain`, postBody)
+
+    onSuccess()
+    return { status: 'success', message: 'succesfully opted into channel' }
+  } catch (err) {
+    onError(err)
+    return { status: 'error', message: err.message }
+  }
+}
+
+async function optOut(
+  signer,
+  channelAddress,
+  chainId,
+  userAddress,
+  {
+    baseApiUrl = EPNS_CONFIG[chainId].API_BASE_URL,
+    verifyingContractAddress = EPNS_CONFIG[chainId].EPNS_COMMUNICATOR_CONTRACT,
+    onSuccess = () => 'success',
+    onError = () => 'error'
+  } = {}
+) {
+  try {
+    // get domain information
+    const domainInformation = getDomainInformation(
+      chainId,
+      verifyingContractAddress
+    )
+    // get type information
+    const typeInformation = signingConstants.ACTION_TYPES['unsubscribe']
+
+    // get message
+    const messageInformation = getSubscriptionMessage(
+      channelAddress,
+      userAddress,
+      'Unsubscribe'
+    )
+
+    // sign message
+    const signature = await signer._signTypedData(
+      domainInformation,
+      typeInformation,
+      messageInformation
+    )
+
+    const postBody = JSON.stringify({
+      signature,
+      message: messageInformation,
+      op: 'write',
+      chainId,
+      contractAddress: verifyingContractAddress
+    })
+
+    await fetchPOST(`${baseApiUrl}/channels/unsubscribe_offchain`, postBody)
+
+    onSuccess()
+    return { status: 'success', message: 'succesfully opted out of channel' }
+  } catch (err) {
+    onError(err)
+    return { status: 'error', message: err.message }
+  }
+}
+
+function selectConfig(networkId) {
+  return EPNS_CONFIG[networkId] || {}
+}
+
+/**
+ * Function to obtain all the addresses subscribed to a channel
+ * @param channelAddress the address of the channel
+ * @param userAddress
+ */
+async function getSubscribers(channelAddress, baseApiUrl) {
+  try {
+    const postBody = JSON.stringify({ channel: channelAddress, op: 'read' })
+    const response = await fetchPOST(
+      `${baseApiUrl}/channels/get_subscribers`,
+      postBody
+    )
+
+    return response.subscribers || []
+  } catch (err) {
+    throw err
+  }
+}
+
+async function isUserSubscribed(userAddress, channelAddress, baseApiUrl) {
+  const channelSubscribers = await getSubscribers(channelAddress, baseApiUrl)
+
+  return channelSubscribers
+    .map(a => a.toLowerCase())
+    .includes(userAddress.toLowerCase())
+}
+
+const LINKS = [
+  {
+    text: 'EPNS Browser Extension',
+    link:
+      'https://chrome.google.com/webstore/detail/epns-protocol-alpha/lbdcbpaldalgiieffakjhiccoeebchmg',
+    img: 'https://backend-kovan.epns.io/assets/googlechromeicon.png'
+  },
+  {
+    text: 'EPNS App (iOS)',
+    link: 'https://apps.apple.com/app/ethereum-push-service-epns/id1528614910',
+    img: 'https://backend-kovan.epns.io/assets/apple.png'
+  },
+  {
+    text: 'EPNS App (Android)',
+    link: 'https://play.google.com/store/apps/details?id=io.epns.epns',
+    img: 'https://backend-kovan.epns.io/assets/playstorecolor@3x.png'
+  },
+  {
+    text: 'Visit our dApp',
+    link: 'https://app.epns.io/',
+    img: 'https://backend-kovan.epns.io/assets/dappcolor@3x.png'
+  }
+]
+
+const CLOSE_ICON = 'https://backend-kovan.epns.io/assets/cross.png'
+
+export { optIn, optOut, selectConfig, isUserSubscribed, LINKS, CLOSE_ICON }

--- a/src/components/EPNS/SwitchNetwork.js
+++ b/src/components/EPNS/SwitchNetwork.js
@@ -1,0 +1,39 @@
+import React from 'react'
+import styled from '@emotion/styled'
+import { default as Button } from '../Forms/Button'
+
+const buttonStyles = `
+  padding: 7px 20px;
+  width: 200px;
+`
+
+const SwitchButton = styled(Button)`
+  ${buttonStyles}
+`
+
+const NetworkSwitch = ({ children }) => {
+  async function handleClick(e) {
+    e.preventDefault()
+
+    try {
+      debugger
+      await window.ethereum.request({
+        method: 'wallet_switchEthereumChain',
+        params: [{ chainId: '0x1' }]
+      })
+      console.log('You have switched to the Ethereum Main network')
+    } catch (switchError) {
+      console.error('Cannot switch to the network', switchError)
+    }
+  }
+
+  return (
+    <>
+      <SwitchButton type="hollow-primary" onClick={handleClick}>
+        {children}
+      </SwitchButton>
+    </>
+  )
+}
+
+export default NetworkSwitch

--- a/src/components/EPNS/index.js
+++ b/src/components/EPNS/index.js
@@ -1,0 +1,4 @@
+import EPNSLink from './EPNSLink'
+import EPNSNotificationModal from './EPNSNotificationModal'
+
+export { EPNSLink, EPNSNotificationModal }

--- a/src/components/EPNS/useWeb3.js
+++ b/src/components/EPNS/useWeb3.js
@@ -1,0 +1,24 @@
+import { useEffect, useState } from 'react'
+import { getSigner, getNetworkId } from '@ensdomains/ui'
+
+export function useWeb3Data() {
+  const [signer, setSigner] = useState(null)
+  const [networkId, setNetworkId] = useState(null)
+
+  useEffect(() => {
+    async function init() {
+      const _signer = await getSigner()
+      const _networkId = await getNetworkId()
+
+      setSigner(_signer)
+      setNetworkId(_networkId)
+    }
+
+    init()
+  }, [])
+
+  return {
+    signer,
+    networkId
+  }
+}

--- a/src/components/ExpiryNotification/ExpiryNotifyDropdown.js
+++ b/src/components/ExpiryNotification/ExpiryNotifyDropdown.js
@@ -7,16 +7,19 @@ import EmailNotifyLink from './EmailNotifyLink'
 import Modal from '../Modal/Modal'
 import ExpiryNotificationModal from './ExpiryNotificationModal'
 import { useOnClickOutside } from 'components/hooks'
+import { EPNSLink, EPNSNotificationModal } from '../EPNS'
 
 const ExpiryNotifyDropdownContainer = styled('div')`
   position: relative;
 `
+const customDropdownStyles = { minWidth: 162 }
 
 export default function ExpiryNotifyDropdown({ address }) {
   const dropdownRef = createRef()
   const togglerRef = createRef()
   const [showDropdown, setShowDropdown] = useState(false)
   const [showModal, setShowModal] = useState(false)
+  const [optionSelected, setOptionSelected] = useState(false)
   const { t } = useTranslation()
 
   useOnClickOutside([dropdownRef, togglerRef], () => setShowDropdown(false))
@@ -26,12 +29,20 @@ export default function ExpiryNotifyDropdown({ address }) {
   }
 
   const handleEmailNotifyClick = () => {
+    setOptionSelected('email')
     setShowModal(true)
     setShowDropdown(false)
   }
 
   const handleCloseModal = () => {
     setShowModal(false)
+    setOptionSelected('')
+  }
+
+  const handleEPNSNotifyClick = () => {
+    setOptionSelected('epns')
+    setShowModal(true)
+    setShowDropdown(false)
   }
 
   return (
@@ -40,7 +51,7 @@ export default function ExpiryNotifyDropdown({ address }) {
         {t('expiryNotification.reminder')}
       </CalendarButton>
       {showDropdown && (
-        <Dropdown ref={dropdownRef}>
+        <Dropdown ref={dropdownRef} style={customDropdownStyles}>
           <EmailNotifyLink
             onClick={handleEmailNotifyClick}
             key="email"
@@ -48,13 +59,23 @@ export default function ExpiryNotifyDropdown({ address }) {
           >
             {t('c.email')}
           </EmailNotifyLink>
+
+          <EPNSLink key="epns" onClick={handleEPNSNotifyClick}>
+            {t('epns.link')}
+          </EPNSLink>
         </Dropdown>
       )}
-      {showModal && (
+      {showModal && optionSelected === 'email' && (
         <Modal closeModal={handleCloseModal}>
           <ExpiryNotificationModal
             {...{ address, onCancel: handleCloseModal }}
           />
+        </Modal>
+      )}
+
+      {showModal && optionSelected === 'epns' && (
+        <Modal closeModal={handleCloseModal}>
+          <EPNSNotificationModal {...{ address, onCancel: handleCloseModal }} />
         </Modal>
       )}
     </ExpiryNotifyDropdownContainer>


### PR DESCRIPTION
# Integration of EPNS Opt-in/Opt-out functionality in My Accounts page

## Description
On the My Account page, when the user is shown a "Remind Me" drop down, currently we see only "Email". We are now adding a feature to `Opt-In`/`Opt-Out` to EPNS notifications so that they can receive notifications from ENS.

## List of features added/changed
### UX wise
- A "Wallet Notif (EPNS)" dropdown link below "Email"
- Click on the "Wallet Notif (EPNS)" dropdown link, it will open a modal window which has 3 buttons -
    * **View Supported Platforms**: shows all the EPNS apps on which you can see notifications.
    * **OPT-IN or OPT-OUT**: based on your subscription status at that moment
    * **Cancel**: to close the modal window 

### Code wise
1. The entry point of all the EPNS functionality is in `ExpiryNotifyDropdown` which uses `EPNSLink` from `components/EPNS`

2. An EPNS folder under `components` has been created which has abstracted all the functionality for this feature. Currently this has many inter-connected components-
    * `EPNSLink` - entry point into EPNS feature
    * `EPNSNotificationModal` - kicks in when `EPNSLink` is clicked. This wrapper component is provided to do all the heavy lifting for ENS-EPNS bridging.
    * `SwitchNetwork` - Utility component to give user 1 click switching of Network to Ethereum main net.
    * `useWeb3` hook - This basically gives the `EPNSNotificationModal` component the web3 data to make API calls
    * `EPNSOnSubscribeModal` - [INTERNAL, will be replaced by NPM package in future] 
    * `EPNSUtil` - [INTERNAL, will be replaced by NPM package in future] 

[**INTERNAL**] *Currently we are transitioning to smaller individual packages, to avoid increasing the bundle size for ENS (or any dApp), we have extracted out the individual functionalities for Optin, Optout, OnSubscribeModal and placed them in ENS codebase under `components/EPNS`, when we publish those respective NPM packages the end users can simply `import` these functionalities from the NPM package and delete these files. We will be providing complete support for this.*

3. We have kept all the text content in `en.json` following ENS i18n practices.

## How Has This Been Tested?

#### Locally

1. Ran the app in local with all the changes in ETH Main net with ENS sample account to land to the Home page with "My Account" displayed. Clicked on "My Account".
2. Clicked on "Remind Me". 
3. Clicked on "Wallet Notif (EPNS)"
4. Opens a EPNS Modal with 3 buttons (View Supported Platforms, Opt-In or Opt-Out, Cancel).
5. The Opt-In or Opt-Out button will become visible after the Loading spinner hides because we make an API call to determine the status of the subscription of the user.
6. If we click on Opt-In or Opt-Out, MetaMask pops out prompting to sign a gasless transaction.
7. After MetaMask signing, 
    * if you have opted-in, you will see a `OnSubscribeModal`, the same modal you see when you click on the "View Supported Platforms" button. If you close that modal, you will see the EPNS modal with "Opt-Out" text.
    * if your have opted-out, you will see the 1st modal with "Opt-In" text.
8. Clicking on "Cancel" simply closes the EPNS Modal.
9. Currently EPNS supports Main net, Kovan. So if you open in any other network it will prompt you a message - "Wallet notifications are only supported on the Main net!" and a `Switch` button to switch to Main net.
10. In case of any API error or error in general you may see the following message - 
"Mayday! Mayday! Can the devs do something? They have been notified, please try again a little later!"

#### Unit Tests
1. Ran `npm test` on the entire code base -


    ```
    Test Suites: 25 passed, 25 total
    Tests:       1 todo, 138 passed, 139 total
    Snapshots:   0 total
    Time:        25.034 s
    Ran all test suites.
    ```

#### Screenshots

<img width="1158" alt="Screen Shot 2022-05-11 at 10 12 05 AM" src="https://user-images.githubusercontent.com/6158624/167774234-ee5a0673-b95b-4d6d-98a4-fc1573ed484a.png">
<img width="1425" alt="Screen Shot 2022-05-11 at 10 12 49 AM" src="https://user-images.githubusercontent.com/6158624/167774248-534ba236-0934-4a9f-8c24-9ca063712db4.png">
![Screen Shot 2022-05-11 at 10 44 03 AM](https://user-images.githubusercontent.com/6158624/167774250-e6c31a61-0754-4992-89e9-555897a0e4ab.png)
![Screen Shot 2022-05-11 at 10 44 22 AM](https://user-images.githubusercontent.com/6158624/167774253-d5c36677-b5a7-47f4-b77c-765d0bc6ed0d.png)
![Screen Shot 2022-05-11 at 10 44 31 AM](https://user-images.githubusercontent.com/6158624/167774256-84582b6d-4c8f-4d0b-8e77-c48238aecd3a.png)



## Checklist:
- [x] My code follows the code style of this project.
- [x] My code implements all the required features.
