### PR TITLE
Change redirect logic

### DIFF
--- a/src/components/SingleName/NameDetails.js
+++ b/src/components/SingleName/NameDetails.js
@@ -62,19 +62,12 @@ function NameDetails({
   }
   const showExplainer = !parseInt(domain.resolver)
   const outOfSync = dnssecmode && dnssecmode.outOfSync
-  const isAnAbsolutePath = pathname.split('/').length > 3
-
-  if (domain.parent === 'eth' && tab === 'register' && !isAnAbsolutePath) {
-    return <Redirect to={`${pathname}/register`} />
-  } else if (
-    domain.parent === 'eth' &&
-    tab === 'details' &&
-    !isAnAbsolutePath
-  ) {
-    return <Redirect to={`${pathname}/details`} />
-  } else if (domain.parent !== 'eth' && !isAnAbsolutePath) {
-    //subdomain or dns
-    return <Redirect to={`${pathname}/subdomains`} />
+  const pathnamewithoutslash = pathname.replace(/\/$/, '')
+  const needRedirect = !pathnamewithoutslash.match(
+    '/register$|/details$|/subdomains$'
+  )
+  if (needRedirect) {
+    return <Redirect to={`${pathnamewithoutslash}/${tab}`} />
   }
 
   return (

--- a/src/components/SingleName/NameDetails.spec.js
+++ b/src/components/SingleName/NameDetails.spec.js
@@ -24,7 +24,7 @@ import NameDetails from './NameDetails'
 const mocks = []
 
 describe('NameDetails', () => {
-  const pathname = '/name/vitalik.eth'
+  const pathnameroot = '/name/vitalik.eth'
   afterEach(() => {
     useQuery.mockClear()
   })
@@ -33,7 +33,7 @@ describe('NameDetails', () => {
       domain: {
         name: 'vitalik.eth'
       },
-      pathname,
+      pathname: pathnameroot,
       tab: 'register'
     }
 
@@ -44,7 +44,7 @@ describe('NameDetails', () => {
       loading: true
     }))
 
-    const context = {}
+    const context = { url: pathnameroot }
     render(
       <StaticRouter location={'/'} context={context}>
         <MockedProvider mocks={mocks} addTypename={false}>
@@ -52,14 +52,14 @@ describe('NameDetails', () => {
         </MockedProvider>
       </StaticRouter>
     )
-    expect(context.url).toEqual(`${pathname}/register`)
+    expect(context.url).toEqual(`${pathnameroot}/register`)
   })
   it('should redirect to /details if tab is not register', () => {
     const mockProps = {
       domain: {
         name: 'vitalik.eth'
       },
-      pathname: pathname + '/',
+      pathname: pathnameroot + '/',
       tab: 'details'
     }
 
@@ -70,7 +70,7 @@ describe('NameDetails', () => {
       loading: true
     }))
 
-    const context = {}
+    const context = { url: pathnameroot }
     render(
       <StaticRouter location={'/'} context={context}>
         <MockedProvider mocks={mocks} addTypename={false}>
@@ -78,14 +78,14 @@ describe('NameDetails', () => {
         </MockedProvider>
       </StaticRouter>
     )
-    expect(context.url).toEqual(`${pathname}/details`)
+    expect(context.url).toEqual(`${pathnameroot}/details`)
   })
-  it('should not redirect to /subdomains if subdomains tab and is not an absolute path', () => {
+  it('should not redirect to /subdomains if already in subdomains', () => {
     const mockProps = {
       domain: {
         name: 'vitalik.eth'
       },
-      pathname: `${pathname}/subdomains`,
+      pathname: `${pathnameroot}/subdomains`,
       tab: 'subdomains'
     }
 
@@ -96,7 +96,7 @@ describe('NameDetails', () => {
       loading: true
     }))
 
-    const context = {}
+    const context = { url: `${pathnameroot}/subdomains` }
     render(
       <StaticRouter location={'/'} context={context}>
         <MockedProvider mocks={mocks} addTypename={false}>
@@ -104,8 +104,7 @@ describe('NameDetails', () => {
         </MockedProvider>
       </StaticRouter>
     )
-    // TODO: Is there better way to test that redirect does not happen?
-    expect(context.url).toEqual(undefined)
+    expect(context.url).toEqual(`${pathnameroot}/subdomains`)
   })
   it('should pass isMigrated loading state to DetailsContainer', () => {
     const mockProps = {

--- a/src/components/SingleName/NameDetails.spec.js
+++ b/src/components/SingleName/NameDetails.spec.js
@@ -54,6 +54,7 @@ describe('NameDetails', () => {
     )
     expect(context.url).toEqual(`${pathnameroot}/register`)
   })
+
   it('should redirect to /details if tab is not register', () => {
     const mockProps = {
       domain: {
@@ -80,32 +81,37 @@ describe('NameDetails', () => {
     )
     expect(context.url).toEqual(`${pathnameroot}/details`)
   })
-  it('should not redirect to /subdomains if already in subdomains', () => {
-    const mockProps = {
-      domain: {
-        name: 'vitalik.eth'
-      },
-      pathname: `${pathnameroot}/subdomains`,
-      tab: 'subdomains'
-    }
+  const array = ['register', 'details', 'subdomains']
+  for (let index = 0; index < array.length; index++) {
+    const tab = array[index]
+    it(`should not redirect to /${tab} if already in ${tab}`, () => {
+      const mockProps = {
+        domain: {
+          name: 'vitalik.eth'
+        },
+        pathname: `${pathnameroot}/${tab}`,
+        tab
+      }
 
-    useQuery.mockImplementation(() => ({
-      data: {
-        isMigrated: true
-      },
-      loading: true
-    }))
+      useQuery.mockImplementation(() => ({
+        data: {
+          isMigrated: true
+        },
+        loading: true
+      }))
 
-    const context = { url: `${pathnameroot}/subdomains` }
-    render(
-      <StaticRouter location={'/'} context={context}>
-        <MockedProvider mocks={mocks} addTypename={false}>
-          <NameDetails {...mockProps} />
-        </MockedProvider>
-      </StaticRouter>
-    )
-    expect(context.url).toEqual(`${pathnameroot}/subdomains`)
-  })
+      const context = { url: `${pathnameroot}/${tab}` }
+      render(
+        <StaticRouter location={'/'} context={context}>
+          <MockedProvider mocks={mocks} addTypename={false}>
+            <NameDetails {...mockProps} />
+          </MockedProvider>
+        </StaticRouter>
+      )
+      expect(context.url).toEqual(`${pathnameroot}/${tab}`)
+    })
+  }
+
   it('should pass isMigrated loading state to DetailsContainer', () => {
     const mockProps = {
       domain: {

--- a/src/components/SingleName/NameDetails.spec.js
+++ b/src/components/SingleName/NameDetails.spec.js
@@ -3,6 +3,7 @@ import { render } from '@testing-library/react'
 import '@testing-library/jest-dom'
 import { MockedProvider } from '@apollo/client/testing'
 import { StaticRouter } from 'react-router-dom'
+import { createBrowserHistory } from 'history'
 
 jest.mock('@apollo/client', () => ({
   __esModule: true,
@@ -23,16 +24,16 @@ import NameDetails from './NameDetails'
 const mocks = []
 
 describe('NameDetails', () => {
+  const pathname = '/name/vitalik.eth'
   afterEach(() => {
     useQuery.mockClear()
   })
-  it('should redirect to /register if register tab and is not an absolute path', () => {
+  it('should redirect to /register if register tab is register', () => {
     const mockProps = {
       domain: {
-        name: 'vitalik.eth',
-        parent: 'eth'
+        name: 'vitalik.eth'
       },
-      pathname: '',
+      pathname,
       tab: 'register'
     }
 
@@ -51,15 +52,14 @@ describe('NameDetails', () => {
         </MockedProvider>
       </StaticRouter>
     )
-    expect(context.url).toEqual('/register')
+    expect(context.url).toEqual(`${pathname}/register`)
   })
-  it('should redirect to /details if details tab and is not an absolute path', () => {
+  it('should redirect to /details if tab is not register', () => {
     const mockProps = {
       domain: {
-        name: 'vitalik.eth',
-        parent: 'eth'
+        name: 'vitalik.eth'
       },
-      pathname: '',
+      pathname: pathname + '/',
       tab: 'details'
     }
 
@@ -78,15 +78,14 @@ describe('NameDetails', () => {
         </MockedProvider>
       </StaticRouter>
     )
-    expect(context.url).toEqual('/details')
+    expect(context.url).toEqual(`${pathname}/details`)
   })
-  it('should redirect to /subdomains if subdomains tab and is not an absolute path', () => {
+  it('should not redirect to /subdomains if subdomains tab and is not an absolute path', () => {
     const mockProps = {
       domain: {
-        name: 'sub.vitalik.eth',
-        parent: 'vitalik'
+        name: 'vitalik.eth'
       },
-      pathname: '',
+      pathname: `${pathname}/subdomains`,
       tab: 'subdomains'
     }
 
@@ -105,7 +104,8 @@ describe('NameDetails', () => {
         </MockedProvider>
       </StaticRouter>
     )
-    expect(context.url).toEqual('/subdomains')
+    // TODO: Is there better way to test that redirect does not happen?
+    expect(context.url).toEqual(undefined)
   })
   it('should pass isMigrated loading state to DetailsContainer', () => {
     const mockProps = {


### PR DESCRIPTION
This fixes thw two issues

- https://app.ens.domains/name/name/matoken.eth/ (with trailing `/` does not redirect to https://app.ens.domains/name/name/matoken.eth)
- https://app.ens.domains/name/name/argent.xyz and https://app.ens.domains/name/1.offchainexample.eth (subdomains and non .eth domains) redirecting to /subdomains instead of /details