### PR TITLE
Fix NameRegister connection status

### DIFF
--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -174,6 +174,7 @@
   },
   "register": {
     "buttons": {
+      "connect": "No wallet connected. Please connect a wallet to continue.",
       "insufficient": "Insufficient balance on your wallet. Fill in your wallet and reload the page.",
       "manage": "Manage name",
       "register": "Register",

--- a/src/components/SingleName/Name.js
+++ b/src/components/SingleName/Name.js
@@ -87,24 +87,26 @@ const NAME_REGISTER_DATA_WRAPPER = gql`
   query nameRegisterDataWrapper @client {
     accounts
     networkId
+    isReadOnly
   }
 `
 
 export const useRefreshComponent = () => {
   const [key, setKey] = useState(0)
   const {
-    data: { accounts, networkId }
+    data: { accounts, networkId, isReadOnly }
   } = useQuery(NAME_REGISTER_DATA_WRAPPER)
   const mainAccount = accounts?.[0]
   useEffect(() => {
     setKey(x => x + 1)
-  }, [mainAccount, networkId])
+  }, [mainAccount, networkId, isReadOnly])
   return key
 }
 
-const NAME_QUERY = gql`
-  query nameQuery {
-    accounts @client
+const ACCOUNT_CONNECTED_QUERY = gql`
+  query nameQuery @client {
+    accounts
+    isReadOnly
   }
 `
 
@@ -114,8 +116,8 @@ function Name({ details: domain, name, pathname, type, refetch }) {
   const percentDone = 0
 
   const {
-    data: { accounts }
-  } = useQuery(NAME_QUERY)
+    data: { accounts, isReadOnly }
+  } = useQuery(ACCOUNT_CONNECTED_QUERY)
 
   const account = accounts?.[0]
   const isOwner = isOwnerOfDomain(domain, account)
@@ -231,7 +233,8 @@ function Name({ details: domain, name, pathname, type, refetch }) {
             refetch={refetch}
             account={account}
             registrationOpen={registrationOpen}
-            readOnly={isNameWrapped}
+            isNameWrapped={isNameWrapped}
+            isReadOnly={isReadOnly}
           />
         )}
       </NameContainer>

--- a/src/components/SingleName/NameDetails.js
+++ b/src/components/SingleName/NameDetails.js
@@ -4,8 +4,6 @@ import { Route, Redirect } from 'react-router-dom'
 
 import { IS_MIGRATED } from '../../graphql/queries'
 
-import { isEmptyAddress } from '../../utils/records'
-
 import NameRegister from './NameRegister'
 import SubDomains from './SubDomains'
 import dnssecmodes from '../../api/dnssecmodes'
@@ -20,7 +18,8 @@ function NameDetails({
   registrationOpen,
   tab,
   pathname,
-  readOnly = false
+  isNameWrapped = false,
+  isReadOnly = true
 }) {
   const [loading, setLoading] = useState(undefined)
   const {
@@ -102,7 +101,7 @@ function NameDetails({
               dnssecmode={dnssecmode}
               account={account}
               refetchIsMigrated={refetchIsMigrated}
-              readOnly={readOnly}
+              readOnly={isNameWrapped}
             />
           )
         }}
@@ -120,7 +119,7 @@ function NameDetails({
             loadingIsMigrated={loadingIsMigrated}
             isParentMigratedToNewRegistry={isParentMigratedToNewRegistry}
             loadingIsParentMigrated={loadingIsParentMigrated}
-            readOnly={readOnly}
+            readOnly={isNameWrapped}
           />
         )}
       />
@@ -134,7 +133,8 @@ function NameDetails({
             domain={domain}
             refetch={refetch}
             refetchIsMigrated={refetchIsMigrated}
-            readOnly={readOnly || isEmptyAddress(account)}
+            isNameWrapped={isNameWrapped}
+            isReadOnly={isReadOnly}
           />
         )}
       />

--- a/src/components/SingleName/NameRegister/CTA.js
+++ b/src/components/SingleName/NameRegister/CTA.js
@@ -11,13 +11,14 @@ import EthVal from 'ethval'
 import { trackReferral } from '../../../utils/analytics'
 import { COMMIT, REGISTER } from '../../../graphql/mutations'
 
-import Tooltip from 'components/Tooltip/Tooltip'
 import PendingTx from '../../PendingTx'
 import Button from '../../Forms/Button'
 import AddToCalendar from '../../Calendar/RenewalCalendar'
 import { ReactComponent as DefaultPencil } from '../../Icons/SmallPencil.svg'
 import { ReactComponent as DefaultOrangeExclamation } from '../../Icons/OrangeExclamation.svg'
 import { useAccount } from '../../QueryAccount'
+import { connectProvider } from '../../../utils/providerUtils'
+import NoAccountsModal from '../../NoAccounts/NoAccountsModal'
 
 const CTAContainer = styled('div')`
   display: flex;
@@ -58,7 +59,8 @@ function getCTA({
   isAboveMinDuration,
   refetch,
   refetchIsMigrated,
-  readOnly,
+  isNameWrapped,
+  isReadOnly,
   price,
   years,
   premium,
@@ -67,6 +69,7 @@ function getCTA({
   ethUsdPrice,
   account
 }) {
+  console.log(isNameWrapped, isReadOnly)
   const CTAs = {
     PRICE_DECISION: (
       <Mutation
@@ -80,7 +83,7 @@ function getCTA({
         }}
       >
         {mutate =>
-          isAboveMinDuration && !readOnly ? (
+          isAboveMinDuration && !isNameWrapped && !isReadOnly ? (
             hasSufficientBalance ? (
               <Button data-testid="request-register-button" onClick={mutate}>
                 {t('register.buttons.request')}
@@ -96,30 +99,18 @@ function getCTA({
                 </Button>
               </>
             )
-          ) : readOnly ? (
-            <Tooltip
-              text="<p>You are not connected to a web3 browser. Please connect to a web3 browser and try again</p>"
-              position="top"
-              border={true}
-              offset={{ left: -30, top: 10 }}
-            >
-              {({ showTooltip, hideTooltip }) => {
-                return (
-                  <Button
-                    data-testid="request-register-button"
-                    type="disabled"
-                    onMouseOver={() => {
-                      showTooltip()
-                    }}
-                    onMouseLeave={() => {
-                      hideTooltip()
-                    }}
-                  >
-                    {t('register.buttons.request')}
-                  </Button>
-                )
-              }}
-            </Tooltip>
+          ) : !isNameWrapped ? (
+            <>
+              <Prompt>
+                <OrangeExclamation />
+                {t('register.buttons.connect')}
+              </Prompt>
+              <NoAccountsModal
+                onClick={connectProvider}
+                colour={'#F5A623'}
+                buttonText={t('c.connect')}
+              />
+            </>
           ) : (
             <Button data-testid="request-register-button" type="disabled">
               {t('register.buttons.request')}
@@ -244,7 +235,8 @@ const CTA = ({
   isAboveMinDuration,
   refetch,
   refetchIsMigrated,
-  readOnly,
+  isReadOnly,
+  isNameWrapped,
   price,
   years,
   premium,
@@ -281,7 +273,8 @@ const CTA = ({
         isAboveMinDuration,
         refetch,
         refetchIsMigrated,
-        readOnly,
+        isNameWrapped,
+        isReadOnly,
         price,
         years,
         premium,

--- a/src/components/SingleName/NameRegister/CTA.js
+++ b/src/components/SingleName/NameRegister/CTA.js
@@ -69,7 +69,6 @@ function getCTA({
   ethUsdPrice,
   account
 }) {
-  console.log(isNameWrapped, isReadOnly)
   const CTAs = {
     PRICE_DECISION: (
       <Mutation

--- a/src/components/SingleName/NameRegister/NameRegister.js
+++ b/src/components/SingleName/NameRegister/NameRegister.js
@@ -46,7 +46,8 @@ const NameRegister = ({
   waitTime,
   refetch,
   refetchIsMigrated,
-  readOnly,
+  isReadOnly,
+  isNameWrapped,
   registrationOpen
 }) => {
   const { t } = useTranslation()
@@ -328,7 +329,8 @@ const NameRegister = ({
         refetch={refetch}
         refetchIsMigrated={refetchIsMigrated}
         isAboveMinDuration={isAboveMinDuration}
-        readOnly={readOnly}
+        isReadOnly={isReadOnly}
+        isNameWrapped={isNameWrapped}
         price={getRentPrice}
         years={years}
         premium={currentPremium}


### PR DESCRIPTION
Before:
- The registration page would show an insufficient balance message if no wallet was connected
- The connect button was not easily seen anywhere on the page on mobile
- "readOnly" was being interchanged between readOnly state for disconnected wallet, and readOnly state for being a wrapped name.

After:
- The registration page shows a message that a wallet needs to be connected
- A connect button is shown as a replacement for the request to register
- "readOnly" was replaced with "isNameWrapped" and "isReadOnly"

Related issue: #1513 