### PR TITLE
fix: emoji names

### DIFF
--- a/scripts/serve.js
+++ b/scripts/serve.js
@@ -40,6 +40,11 @@ config.module.rules.push({
 
 config.bail = false
 
+config.resolve.alias['@ethersproject/hash'] = path.resolve(
+  __dirname,
+  '../src/hash/index.js'
+)
+
 config.resolve.fallback = {
   http: false,
   https: false,

--- a/src/hash/index.js
+++ b/src/hash/index.js
@@ -1,0 +1,17 @@
+import { id } from '../../node_modules/@ethersproject/hash/lib/id.js'
+import {
+  hashMessage,
+  messagePrefix
+} from '../../node_modules/@ethersproject/hash/lib/message.js'
+import { _TypedDataEncoder } from '../../node_modules/@ethersproject/hash/lib/typed-data.js'
+import { dnsEncode, isValidName, namehash } from './namehash'
+
+export {
+  id,
+  dnsEncode,
+  namehash,
+  isValidName,
+  messagePrefix,
+  hashMessage,
+  _TypedDataEncoder
+}

--- a/src/hash/namehash.js
+++ b/src/hash/namehash.js
@@ -1,0 +1,15 @@
+import { validate } from '@ensdomains/ens-validation'
+import { hash } from '@ensdomains/eth-ens-namehash'
+import packet from 'dns-packet'
+
+export function isValidName(name) {
+  return validate(name)
+}
+
+export function namehash(name) {
+  return hash(name)
+}
+
+export function dnsEncode(name) {
+  return '0x' + packet.name.encode(name).toString('hex')
+}


### PR DESCRIPTION
- emoji names are currently broken (see #1504)
- this is because of ensdomains/UI's reliance on ethers Resolvers which use ethers namehash
- ethers namehash function is a different implementation to what is used in the rest of the app
- this PR overwrites that function, allowing emoji names to work