### PR TITLE
Improve Resolver UX

### DIFF
--- a/cypress/integration/nameDetail.spec.js
+++ b/cypress/integration/nameDetail.spec.js
@@ -101,6 +101,9 @@ describe('Name detail view', () => {
 
   it('can change the resolver to the public resolver', () => {
     cy.visit(`${NAME_ROOT}/superawesome.eth`)
+    cy.getByTestId('advanced-settings-button', { timeout: 10000 }).click({
+      force: true
+    })
     waitUntilInputResolves({ type: 'testId', value: 'edit-resolver' }).then(
       () => {
         cy.getByTestId('edit-resolver').click({ force: true })
@@ -141,6 +144,9 @@ describe('Name detail view', () => {
 
   it('cannot change the resolver to a non contract address', () => {
     cy.visit(`${NAME_ROOT}/superawesome.eth`)
+    cy.getByTestId('advanced-settings-button', { timeout: 10000 }).click({
+      force: true
+    })
     waitUntilInputResolves({ type: 'testId', value: 'edit-resolver' }).then(
       () => {
         cy.getByTestId('edit-resolver').click({ force: true })

--- a/cypress/integration/nameWrapper.spec.js
+++ b/cypress/integration/nameWrapper.spec.js
@@ -57,9 +57,7 @@ describe('Name Wrapper Tests', () => {
         'background-color',
         DISABLED_COLOUR
       )
-      cy.getByTestId('advanced-settings-button', { timeout: 10000 }).click({
-        force: true
-      })
+      cy.getByTestId('advanced-settings-button').click({ force: true })
       cy.getByTestId('edit-resolver').should(
         'have.css',
         'background-color',
@@ -96,9 +94,7 @@ describe('Name Wrapper Tests', () => {
         'background-color',
         DISABLED_COLOUR
       )
-      cy.getByTestId('advanced-settings-button', { timeout: 10000 }).click({
-        force: true
-      })
+      cy.getByTestId('advanced-settings-button').click({ force: true })
       cy.getByTestId('edit-resolver').should(
         'have.css',
         'background-color',
@@ -141,9 +137,7 @@ describe('Name Wrapper Tests', () => {
         'background-color',
         'rgb(83, 132, 254)'
       )
-      cy.getByTestId('advanced-settings-button', { timeout: 10000 }).click({
-        force: true
-      })
+      cy.getByTestId('advanced-settings-button').click({ force: true })
       cy.getByTestId('edit-resolver').should(
         'have.css',
         'background-color',
@@ -193,9 +187,7 @@ describe('Name Wrapper Tests', () => {
         'background-color',
         'rgb(83, 132, 254)'
       )
-      cy.getByTestId('advanced-settings-button', { timeout: 10000 }).click({
-        force: true
-      })
+      cy.getByTestId('advanced-settings-button').click({ force: true })
       cy.getByTestId('edit-resolver').should(
         'have.css',
         'background-color',

--- a/cypress/integration/nameWrapper.spec.js
+++ b/cypress/integration/nameWrapper.spec.js
@@ -57,6 +57,9 @@ describe('Name Wrapper Tests', () => {
         'background-color',
         DISABLED_COLOUR
       )
+      cy.getByTestId('advanced-settings-button', { timeout: 10000 }).click({
+        force: true
+      })
       cy.getByTestId('edit-resolver').should(
         'have.css',
         'background-color',
@@ -93,6 +96,9 @@ describe('Name Wrapper Tests', () => {
         'background-color',
         DISABLED_COLOUR
       )
+      cy.getByTestId('advanced-settings-button', { timeout: 10000 }).click({
+        force: true
+      })
       cy.getByTestId('edit-resolver').should(
         'have.css',
         'background-color',
@@ -135,6 +141,9 @@ describe('Name Wrapper Tests', () => {
         'background-color',
         'rgb(83, 132, 254)'
       )
+      cy.getByTestId('advanced-settings-button', { timeout: 10000 }).click({
+        force: true
+      })
       cy.getByTestId('edit-resolver').should(
         'have.css',
         'background-color',
@@ -184,6 +193,9 @@ describe('Name Wrapper Tests', () => {
         'background-color',
         'rgb(83, 132, 254)'
       )
+      cy.getByTestId('advanced-settings-button', { timeout: 10000 }).click({
+        force: true
+      })
       cy.getByTestId('edit-resolver').should(
         'have.css',
         'background-color',

--- a/cypress/integration/nameWrapper.spec.js
+++ b/cypress/integration/nameWrapper.spec.js
@@ -57,6 +57,7 @@ describe('Name Wrapper Tests', () => {
         'background-color',
         DISABLED_COLOUR
       )
+      cy.wait(5000)
       cy.getByTestId('advanced-settings-button').click({ force: true })
       cy.getByTestId('edit-resolver').should(
         'have.css',
@@ -94,6 +95,7 @@ describe('Name Wrapper Tests', () => {
         'background-color',
         DISABLED_COLOUR
       )
+      cy.wait(5000)
       cy.getByTestId('advanced-settings-button').click({ force: true })
       cy.getByTestId('edit-resolver').should(
         'have.css',
@@ -137,6 +139,7 @@ describe('Name Wrapper Tests', () => {
         'background-color',
         'rgb(83, 132, 254)'
       )
+      cy.wait(5000)
       cy.getByTestId('advanced-settings-button').click({ force: true })
       cy.getByTestId('edit-resolver').should(
         'have.css',
@@ -187,6 +190,7 @@ describe('Name Wrapper Tests', () => {
         'background-color',
         'rgb(83, 132, 254)'
       )
+      cy.wait(5000)
       cy.getByTestId('advanced-settings-button').click({ force: true })
       cy.getByTestId('edit-resolver').should(
         'have.css',

--- a/cypress/integration/resolverMigration.spec.js
+++ b/cypress/integration/resolverMigration.spec.js
@@ -6,7 +6,7 @@ const DISABLED_COLOUR = 'rgb(223, 223, 223)'
 describe('Migrate resolver and records', () => {
   it('can visit a name with an old content resolver and migrate it as swarm contenthash', () => {
     cy.visit(`${ROOT}/name/oldresolver.eth`)
-    cy.getByText('Migrate', { timeout: 10000 }).click({ force: true })
+    cy.getByText('Migrate').click({ force: true, timeout: 1000 })
     cy.queryByText('migrate', { timeout: 10000 }).should('not.exist')
   })
 
@@ -16,6 +16,7 @@ describe('Migrate resolver and records', () => {
       timeout: 5000,
       exact: false
     }).should('exist')
+    cy.getByTestId('advanced-settings-button').click({ force: true })
     cy.queryByTestId('edit-resolver').should(
       'have.css',
       'background-color',
@@ -29,6 +30,7 @@ describe('Migrate resolver and records', () => {
       exact: false,
       timeout: 5000
     }).should('exist')
+    cy.getByTestId('advanced-settings-button').click({ force: true })
     cy.queryByTestId('edit-resolver').should(
       'have.css',
       'background-color',

--- a/cypress/integration/search.spec.js
+++ b/cypress/integration/search.spec.js
@@ -41,6 +41,9 @@ describe(
         'have.text',
         Cypress.env('ownerAddress')
       )
+      cy.getByTestId('advanced-settings-button', { timeout: 10000 }).click({
+        force: true
+      })
       cy.getByTestId('details-value-resolver', { exact: false }).should(
         'have.text',
         Cypress.env('resolverAddress')

--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -339,7 +339,8 @@
       "placeholder": "Use the Public Resolver or enter the address of your custom resolver contract",
       "publicResolver": "Use Public Resolver",
       "resolverAddressWarning": "Only contract address is allowed",
-      "warning": "You’re using an outdated version of the public resolver. Click to migrate your resolver and records. You will need to confirm two transactions in order to migrate both your records and resolver."
+      "warning": "You’re using an outdated version of the public resolver. Click to migrate your resolver and records. You will need to confirm two transactions in order to migrate both your records and resolver.",
+      "info": "The Resolver stores all of your records like addresses, text records, and more. You should only change this if you know what you are doing."
     },
     "search": {
       "title": "Names"
@@ -352,7 +353,8 @@
     "tabs": {
       "details": "Details",
       "register": "Register",
-      "subdomains": "Subdomains"
+      "subdomains": "Subdomains",
+      "advancedSettings": "Advanced Settings"
     },
     "test": {
       "note": "Note: .test domain allows anyone to claim an unused name for test purposes, which expires after 28 days"

--- a/src/api/manager/resolvers.js
+++ b/src/api/manager/resolvers.js
@@ -898,7 +898,7 @@ const resolvers = {
 
       async function getAllRecordsNew(name, publicResolver) {
         const promises = [
-          ens.getEthAddressWithResolver(name, publicResolver),
+          ens.getAddrWithResolver(name, publicResolver),
           getContenthashWithResolver(name, publicResolver),
           getAllTextRecordsWithResolver(name, publicResolver),
           getAllAddressesWithResolver(name, publicResolver)

--- a/src/components/SingleName/DetailsItemEditable.js
+++ b/src/components/SingleName/DetailsItemEditable.js
@@ -45,6 +45,7 @@ import DefaultPricer from './Pricer'
 import DefaultAddressInput from '@ensdomains/react-ens-address'
 import CopyToClipboard from '../CopyToClipboard/'
 import { isOwnerOfParentDomain } from '../../utils/utils'
+import { ReactComponent as DefaultOrangeExclamation } from '../Icons/OrangeExclamation.svg'
 
 const AddressInput = styled(DefaultAddressInput)`
   margin-bottom: 10px;
@@ -167,6 +168,23 @@ const ResolverAddressWarning = styled('span')`
   color: #f6412d;
   margin-left: 3em;
   margin-right: auto;
+`
+
+const ResolverInfoWarning = styled.div`
+  color: #f5a524;
+
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: flex-start;
+  gap: 8px;
+
+  font-weight: bold;
+
+  & > svg {
+    width: 11px;
+    height: 11px;
+  }
 `
 
 const SaveCancel = motion.custom(DefaultSaveCancel)
@@ -342,7 +360,8 @@ const Editable = ({
   variableName,
   refetch,
   confirm,
-  copyToClipboard
+  copyToClipboard,
+  needsToBeMigrated
 }) => {
   const { t } = useTranslation()
   const { state, actions } = useEditable()
@@ -599,6 +618,14 @@ const Editable = ({
             }}
             transition={{ ease: 'easeOut', duration: 0.3 }}
           >
+            {keyName === 'Resolver' && !needsToBeMigrated && (
+              <ResolverInfoWarning>
+                <DefaultOrangeExclamation />
+                <p style={{ color: '#F5A524' }}>
+                  {t('singleName.resolver.info')}
+                </p>
+              </ResolverInfoWarning>
+            )}
             <EditRecord
               initial={{
                 scale: 0,

--- a/src/components/SingleName/ResolverAndRecords/ResolverAndRecords.js
+++ b/src/components/SingleName/ResolverAndRecords/ResolverAndRecords.js
@@ -10,6 +10,8 @@ import ArtRecords from './ArtRecords'
 
 import ResolverMigration from './ResolverMigration'
 import DetailsItemEditable from '../DetailsItemEditable'
+import mq from 'mediaQuery'
+import RotatingSmallCaret from 'components/Icons/RotatingSmallCaret'
 
 const MigrationWarningContainer = styled('div')`
   margin-bottom: 20px;
@@ -43,7 +45,62 @@ const ResolverWrapper = styled('div')`
     padding: 20px;
     margin-bottom: 20px;
   `
-      : 'background: none;'}
+      : `
+      background: none;
+      padding: 20px;
+      `}
+`
+
+const ResolverDropdown = styled.div`
+  border-radius: 6px;
+  display: flex;
+  flex-direction: column;
+
+  & > div:last-child {
+    border-top: 1px dashed #d3d3d3;
+    padding: 0;
+    padding-top: 32px;
+  }
+`
+
+const AdvancedButton = styled.button`
+  border: none;
+  background: none;
+
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+
+  padding: 12px 0;
+  align-self: flex-start;
+
+  cursor: pointer;
+
+  transition: 0.15s filter ease-in-out;
+  filter: opacity(1);
+
+  &:hover {
+    filter: opacity(0.5);
+  }
+
+  p {
+    font-family: Overpass;
+    font-size: 14px;
+    letter-spacing: 0px;
+    font-weight: 600;
+    text-transform: uppercase;
+    flex-shrink: 0;
+    display: flex;
+    margin: 0;
+
+    ${mq.small`
+      align-items: center;
+      margin-bottom: 0;
+      font-size: 16px;
+    `}
+  }
 `
 
 function hasAResolver(resolver) {
@@ -60,6 +117,8 @@ export default function ResolverAndRecords({
   readOnly = false
 }) {
   const { t } = useTranslation()
+  const [showingAdvanced, setShowingAdvanced] = React.useState(false)
+
   const hasResolver = hasAResolver(domain.resolver)
   let isOldPublicResolver = false
   let isDeprecatedResolver = false
@@ -88,60 +147,39 @@ export default function ResolverAndRecords({
     (isOldPublicResolver || isDeprecatedResolver)
   return (
     <>
-      <ResolverWrapper needsToBeMigrated={needsToBeMigrated}>
-        {needsToBeMigrated ? (
-          <>
-            <ResolverMigration
-              value={domain.resolver}
-              name={domain.name}
-              refetch={refetch}
-              isOwner={isOwner}
-              readOnly={readOnly}
-            />
-          </>
-        ) : (
-          <DetailsItemEditable
-            keyName="Resolver"
-            type="address"
+      {needsToBeMigrated && (
+        <ResolverWrapper needsToBeMigrated>
+          <ResolverMigration
             value={domain.resolver}
-            canEdit={isOwner && isMigratedToNewRegistry && !readOnly}
-            domain={domain}
-            editButton={t('c.set')}
-            mutationButton={t('c.save')}
-            mutation={SET_RESOLVER}
+            name={domain.name}
             refetch={refetch}
-            account={account}
-            needsToBeMigrated={needsToBeMigrated}
-            copyToClipboard={true}
+            isOwner={isOwner}
+            readOnly={readOnly}
           />
-        )}
-        {needsToBeMigrated && (
-          <>
-            <MigrationWarning />
-            <ManualMigration>
-              <ManualMigrationMessage>
-                {t('singleName.resolver.message')}
-              </ManualMigrationMessage>
-              <DetailsItemEditable
-                showLabel={false}
-                keyName="Resolver"
-                type="address"
-                value={domain.resolver}
-                canEdit={isOwner && isMigratedToNewRegistry && !readOnly}
-                domain={domain}
-                editButton={t('c.set')}
-                editButtonType="hollow-primary"
-                mutationButton={t('c.save')}
-                backgroundStyle="warning"
-                mutation={SET_RESOLVER}
-                refetch={refetch}
-                account={account}
-                needsToBeMigrated={needsToBeMigrated}
-              />
-            </ManualMigration>
-          </>
-        )}
-      </ResolverWrapper>
+          <MigrationWarning />
+          <ManualMigration>
+            <ManualMigrationMessage>
+              {t('singleName.resolver.message')}
+            </ManualMigrationMessage>
+            <DetailsItemEditable
+              showLabel={false}
+              keyName="Resolver"
+              type="address"
+              value={domain.resolver}
+              canEdit={isOwner && isMigratedToNewRegistry && !readOnly}
+              domain={domain}
+              editButton={t('c.set')}
+              editButtonType="hollow-primary"
+              mutationButton={t('c.save')}
+              backgroundStyle="warning"
+              mutation={SET_RESOLVER}
+              refetch={refetch}
+              account={account}
+              needsToBeMigrated={needsToBeMigrated}
+            />
+          </ManualMigration>
+        </ResolverWrapper>
+      )}
 
       {hasResolver && Object.values(domain).filter(x => x).length && (
         <Records
@@ -156,6 +194,36 @@ export default function ResolverAndRecords({
           areRecordsMigrated={areRecordsMigrated}
           readOnly={readOnly}
         />
+      )}
+
+      {!needsToBeMigrated && (
+        <ResolverDropdown>
+          <AdvancedButton
+            data-testid="advanced-settings-button"
+            onClick={() => setShowingAdvanced(prev => !prev)}
+          >
+            <p>{t('singleName.tabs.advancedSettings')}</p>
+            <RotatingSmallCaret rotated={showingAdvanced} start="top" />
+          </AdvancedButton>
+          {showingAdvanced && (
+            <ResolverWrapper>
+              <DetailsItemEditable
+                keyName="Resolver"
+                type="address"
+                value={domain.resolver}
+                canEdit={isOwner && isMigratedToNewRegistry && !readOnly}
+                domain={domain}
+                editButton={t('c.set')}
+                mutationButton={t('c.save')}
+                mutation={SET_RESOLVER}
+                refetch={refetch}
+                account={account}
+                needsToBeMigrated={needsToBeMigrated}
+                copyToClipboard={true}
+              />
+            </ResolverWrapper>
+          )}
+        </ResolverDropdown>
       )}
 
       {hasResolver && <ArtRecords domain={domain} query={GET_TEXT} />}


### PR DESCRIPTION
- hides resolver field under advanced settings at bottom of page
- gives a warning/info message about the resolver
- unmigrated resolver remains unchanged