### PR TITLE
show-invalid-names-with-warning

### DIFF
--- a/src/apollo/apolloClient.js
+++ b/src/apollo/apolloClient.js
@@ -99,7 +99,13 @@ export const updateResponse = response => {
         return
       }
 
-      const hashedName = namehash.hash(responseItem.name)
+      let hashedName
+      try {
+        hashedName = namehash.hash(responseItem.name)
+      } catch (e) {
+        return
+      }
+
       if (responseItem.id !== hashedName) {
         this.update({ ...responseItem, name: hashedName, invalidName: true })
       }


### PR DESCRIPTION
Catch namehash error in order to allow a list of names to be displayed when some of them are invalid

## Issue number
#1533 

## Description

Catch errors in graphql middleware in order to allow invalid names to be displayed with an error

## How Has This Been Tested?

Visited http://localhost:3000/address/0x8ead5a81e5eaab60ee6e24d85b8ed21182a6cc29/registrant?page=1 
