### PR TITLE
Prompt user to switch network if they are on an unsupported one

### DIFF
--- a/src/api/web3modal.js
+++ b/src/api/web3modal.js
@@ -70,7 +70,7 @@ export const connect = async () => {
     return provider
   } catch (e) {
     if (e !== 'Modal closed by user') {
-      throw e
+      throw { error: e, provider: provider }
     }
   }
 }

--- a/src/setup.spec.js
+++ b/src/setup.spec.js
@@ -130,7 +130,7 @@ describe('getProvider', () => {
 
 describe('setWeb3Provider', () => {
   it('should update network id when network id changes', async () => {
-    expect.assertions(1)
+    expect.assertions(2)
     getNetworkId.mockImplementation(() => '2')
     getNetwork.mockImplementation(() => 'Main')
     const mockProvider = {
@@ -147,7 +147,8 @@ describe('setWeb3Provider', () => {
           cb()
         }
       },
-      events: null
+      events: null,
+      request: () => null
     }
     await setWeb3Provider(mockProvider)
   })
@@ -169,7 +170,8 @@ describe('setWeb3Provider', () => {
           cb()
         }
       },
-      events: null
+      events: null,
+      request: () => null
     }
     await setWeb3Provider(mockProvider)
   })
@@ -180,13 +182,14 @@ describe('setWeb3Provider', () => {
     const mockRemoveAllListeners = jest.fn()
     const mockProvider = {
       on: (event, callback) => {},
-      events: { removeAllListeners: mockRemoveAllListeners }
+      events: { removeAllListeners: mockRemoveAllListeners },
+      request: () => null
     }
     await setWeb3Provider(mockProvider)
     expect(mockRemoveAllListeners).toHaveBeenCalled()
   })
   it('should update network when network changes', async () => {
-    expect.assertions(1)
+    expect.assertions(2)
     getNetworkId.mockImplementation(() => 2)
     getNetwork.mockImplementation(() => 'Main')
     const mockProvider = {
@@ -203,12 +206,13 @@ describe('setWeb3Provider', () => {
           cb()
         }
       },
-      events: null
+      events: null,
+      request: () => null
     }
     await setWeb3Provider(mockProvider)
   })
   it('should set global error if chain is changed to an unsupported network', async () => {
-    expect.assertions(2)
+    expect.assertions(4)
     getNetworkId.mockImplementation(() => 2)
     getNetwork.mockImplementation(() => 'Main')
     const mockProvider = {
@@ -226,7 +230,8 @@ describe('setWeb3Provider', () => {
           cb()
         }
       },
-      events: null
+      events: null,
+      request: () => null
     }
     await setWeb3Provider(mockProvider)
   })
@@ -272,7 +277,10 @@ describe('setup', () => {
     jest.clearAllMocks()
     process.env.REACT_APP_STAGE = 'notlocal'
     connect.mockImplementation(() =>
-      Promise.reject(new Error('Unsupported network 124'))
+      Promise.reject({
+        error: new Error('Unsupported network 124'),
+        provider: undefined
+      })
     )
     expect(globalErrorReactive).not.toHaveBeenCalled()
     await getProvider(true)

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -133,7 +133,6 @@ export const parseSearchTerm = async term => {
   } catch (e) {
     return 'invalid'
   }
-  console.log('** parseSearchTerm', { ens })
   const address = await ens.getOwner(tld)
   return _parseSearchTerm(term, true)
 }


### PR DESCRIPTION
## How Has This Been Tested?

Tested with metamask and wallet connect by landing on the page on an unsupported network as well as switching to an unsupported network while using the app.

