### PR TITLE
Track registration source on-chain via ENSIP 14

### DIFF
--- a/src/components/SingleName/NameRegister/ProgressRecorder.js
+++ b/src/components/SingleName/NameRegister/ProgressRecorder.js
@@ -2,7 +2,9 @@ import crypto from 'crypto'
 import moment from 'moment'
 
 function randomSecret() {
-  return '0x' + crypto.randomBytes(32).toString('hex')
+  // Indicate the source via https://github.com/ensdomains/docs/pull/127
+  const platformSource = '4e34d3a8' // first 8 bits of ens.eth namehash
+  return '0x' + platformSource + crypto.randomBytes(28).toString('hex')
 }
 
 const Store = {

--- a/src/components/SingleName/NameRegister/ProgressRecorder.js
+++ b/src/components/SingleName/NameRegister/ProgressRecorder.js
@@ -3,7 +3,7 @@ import moment from 'moment'
 
 function randomSecret() {
   // Indicate the source via https://github.com/ensdomains/docs/pull/127
-  const platformSource = '4e34d3a8' // first 8 bits of ens.eth namehash
+  const platformSource = '9923eb94' // first 8 bytes of enslabs.eth namehash
   return '0x' + platformSource + crypto.randomBytes(28).toString('hex')
 }
 


### PR DESCRIPTION
When generating a secret for registering names, we can use the beginning of the enslabs.eth namehash to track on-chain what portion of registrations are coming from the official manager app as outlined in [ENSIP 14](https://github.com/ensdomains/docs/pull/127).

Before:
```js
'0x' + crypto.randomBytes(32).toString('hex')
```

After:
```js
const platformSource = '9923eb94'
'0x' + platformSource + crypto.randomBytes(28).toString('hex')
```