### PR TITLE
fix: typos in documentation files

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,7 +352,7 @@ steps to mitigate this:
 - Dynamic imports: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import
 
 - Importing only what you need: If you can only import the exact files you need from a module, you
-  can avoid bundling the whole modlue which can be quite large. Typically you can do this by going into
+  can avoid bundling the whole module which can be quite large. Typically you can do this by going into
   the library in your `node_modules` folder and finding the file exact file you need. For example
   if you find the file you need is at `node_modules/@module/src/helpers/index.js` you can do
   `import helper from '@module/src/helpers/index'`.

--- a/src/components/IPFS/config.js
+++ b/src/components/IPFS/config.js
@@ -4,12 +4,12 @@ const TEMPORAL = {
   name: 'Temporal', // Name of the IPFS service
   logo: temporallogo, // Logo used for the login/sign up header
   link: 'https://play2.temporal.cloud', // The link when people click on the logo or manage domains notice
-  host: 'api.ipfs.temporal.cloud', // the IPFS api endpoint used when the etherium profile is set to mainnet
+  host: 'api.ipfs.temporal.cloud', // the IPFS api endpoint used when the ethereum profile is set to mainnet
   dev: 'api.ipfs.temporal.cloud', // the IPFS api endpoint used when not on mainnet
   port: '443', // the port the endpoint is served from
   apiPath: '/api/v0/', // Api path extension if necessary
-  protocol: 'https', // the protocol used to comunicate with the endpoint
-  auth: true, // If the api requires authention headers
+  protocol: 'https', // the protocol used to communicate with the endpoint
+  auth: true, // If the api requires authentication headers
   login: 'https://api.temporal.cloud/v2/auth/login', // the Authentication endpoint to verify users information. Currently supports JWT
   loginDev: 'https://dev.api.temporal.cloud/v2/auth/login', // same as login but used if user is not on mainnet
   signup: 'https://api.temporal.cloud/v2/auth/register',


### PR DESCRIPTION
**Description correction:**
Corrected `modlue` to `module`
Corrected `etherium` to `ethereum`
Corrected `comunicate` to `communicate`
Corrected `authention` to `authentication`